### PR TITLE
Programmatically set RectangleShape2D on background area

### DIFF
--- a/device/globals/background_area.gd
+++ b/device/globals/background_area.gd
@@ -25,9 +25,6 @@ func _enter_tree():
 		var extents = Vector2(size.x / 2, size.y / 2)
 		var transform = Matrix32(Vector2(1, 0), Vector2(0, 1), extents)
 
-		printt(extents)
-		printt(transform)
-
 		var shape = RectangleShape2D.new()
 		shape.set_extents(extents)
 		add_shape(shape)

--- a/device/globals/background_area.gd
+++ b/device/globals/background_area.gd
@@ -10,20 +10,32 @@ func input(viewport, event, shape_idx):
 			get_tree().call_group(0, "game", "clicked", self, get_pos() + Vector2(event.x, event.y))
 		elif (event.button_index == 2):
 			emit_right_click()
-	
-		
+
 func get_action():
 	return action
 
 func _init():
 	add_user_signal("right_click_on_bg")
 
+func _enter_tree():
+	# Use size of background texture to calculate collision shape
+	var background = get_parent().get_node("background")
+	if background:
+		var size = background.get_size()
+		var extents = Vector2(size.x / 2, size.y / 2)
+		var transform = Matrix32(Vector2(1, 0), Vector2(0, 1), extents)
+
+		printt(extents)
+		printt(transform)
+
+		var shape = RectangleShape2D.new()
+		shape.set_extents(extents)
+		add_shape(shape)
+		set_shape_transform(0, transform)
+
 func _ready():
 	connect("input_event", self, "input")
 	add_to_group("background")
-
-	
-	
 
 func emit_right_click():
 	emit_signal("right_click_on_bg")


### PR DESCRIPTION
The new background_area and item_background area scripts are great, but using them is more difficult than it needs to be. This is especially problematic since the new features are mostly undocumented, but having to first set the shape, then figure out how to set a transform and extents is also tricker than the old method of using a TextureFrame for background input, which only requires the user to attach a script.

What this addition does is to automatically set the shape on the Area2D which is used for background input, given that a node named "background" exists. For an example use case, see https://github.com/fleskesvor/escoria/tree/feat/simpler-background-area-test, which also uses the item_background script to make the mountain in the test scene respond to user input.
