### PR TITLE
Make background_area ignore item_background clicks

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -66,6 +66,11 @@ func set_current_tool(p_tool):
 	current_tool = p_tool
 
 func clicked(obj, pos):
+	# If multiple areas are clicked at once, an item_background "wins"
+	if obj.get_type() == "Area2D":
+		for area in obj.get_overlapping_areas():
+			if area.has_method("is_clicked") and area.is_clicked():
+				return
 	joystick_mode = false
 	if !vm.can_interact():
 		return

--- a/device/globals/item_background.gd
+++ b/device/globals/item_background.gd
@@ -21,6 +21,10 @@ var anim_scale_override = null
 var ui_anim = null
 
 var event_table = {}
+var clicked = false
+
+func is_clicked():
+	return clicked
 
 #func _set(name, val):
 #	if name == "events_path":
@@ -89,9 +93,11 @@ func mouse_exit():
 func input(viewport, event, shape_idx):
 	if event.type == InputEvent.MOUSE_BUTTON || event.is_action("ui_accept"):
 		if event.is_pressed():
+			clicked = true
 			get_tree().call_group(0, "game", "clicked", self, get_pos())
 			_check_focus(true, true)
 		else:
+			clicked = false
 			_check_focus(true, false)
 
 func _check_focus(focus, pressed):


### PR DESCRIPTION
Toggle boolean 'clicked' on item_background on mouse press/release to prevent simultaneous clicks on background_area. This should resolve #20.

See https://github.com/fleskesvor/escoria/tree/test/greedy_background_area for a test case using the mountain from device/scenes/test/test.scn as an item_background.