### PR TITLE
[RFC] Set `current = true` on camera to follow player

### DIFF
--- a/device/globals/game.tscn
+++ b/device/globals/game.tscn
@@ -32,7 +32,7 @@ autostart = false
 
 anchor_mode = 1
 rotating = false
-current = false
+current = true
 zoom = Vector2( 1, 1 )
 limit_left = -10000000
 limit_top = -10000000


### PR DESCRIPTION
This does not fix all the problems in #46 but at least it places the camera on the player and respects camera limits, so that's something.

The camera is still zoomed wrong, but I'm almost sure this is a step in the right direction.
