### PR TITLE
Allow setting esc script on scene.gd node and run load commands

### DIFF
--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -73,11 +73,14 @@ func menu_collapse():
 		i -= 1
 		menu_stack[i].menu_collapsed()
 
-func set_current_scene(p_scene):
+func set_current_scene(p_scene, events_path=null):
 	#print_stack()
 	current = p_scene
 	var root = get_tree().get_root()
 	root.move_child(p_scene, 0)
+
+	if events_path:
+		vm.load_file(events_path)
 
 func wait_finished():
 	vm.finished(wait_level)

--- a/device/globals/scene_base.gd
+++ b/device/globals/scene_base.gd
@@ -1,6 +1,7 @@
 extends Node
 
-func _ready():
-	main.call_deferred("set_current_scene", self)
+export(String, FILE) var events_path = ""
 
+func _ready():
+	main.call_deferred("set_current_scene", self, events_path)
 


### PR DESCRIPTION
I haven't tested this properly with dialoge, background music and other things a developer might want to trigger on loading a scene, but setting flags, eg. to add items to inventory, works fine.