### PR TITLE
Allow setting esc script on scene.gd node and run load commands

### DIFF
--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -520,10 +520,16 @@ func load_file(p_game):
 		return
 
 	var game = compile(p_game)
-	clear()
-	loading_game = true
-	run_event(game["load"])
-	main.menu_collapse()
+	# `load` and `ready` are exclusive because you probably don't want to
+	# reset the game state when a scene becomes ready, and `ready` is
+	# redundant when `load`ing state anyway.
+	if "load" in game:
+		clear()
+		loading_game = true
+		run_event(game["load"])
+		main.menu_collapse()
+	elif "ready" in game:
+		run_event(game["ready"])
 
 func load_slot(p_game):
 	var cb = [self, "game_str_loaded"]

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -73,11 +73,14 @@ func menu_collapse():
 		i -= 1
 		menu_stack[i].menu_collapsed()
 
-func set_current_scene(p_scene):
+func set_current_scene(p_scene, events_path=null):
 	#print_stack()
 	current = p_scene
 	var root = get_tree().get_root()
 	root.move_child(p_scene, 0)
+
+	if events_path:
+		vm.load_file(events_path)
 
 func wait_finished():
 	vm.finished(wait_level)

--- a/device/globals/scene_base.gd
+++ b/device/globals/scene_base.gd
@@ -1,6 +1,7 @@
 extends Node
 
-func _ready():
-	main.call_deferred("set_current_scene", self)
+export(String, FILE) var events_path = ""
 
+func _ready():
+	main.call_deferred("set_current_scene", self, events_path)
 


### PR DESCRIPTION
This replaces #56 as discussed on IRC/#escoria.

It introduces a `ready` event that can be used when attaching an esc script to a scene.