### PR TITLE
Fixing the inventory

### DIFF
--- a/device/globals/inventory.gd
+++ b/device/globals/inventory.gd
@@ -20,19 +20,28 @@ func open():
 		return
 	sort_items()
 	show()
-	get_node("animation").play("show")
+	print("inventory open")
+	if has_node("animation"):
+		get_node("animation").play("show")
 
 
 func close():
 	if !is_visible():
 		return
-	if get_node("animation").is_playing():
-		return
-	#printt("closing inventory")
-	print_stack()
-	get_node("animation").play("hide")
-	get_node("look").set_pressed(false)
+
+	if has_node("animation"):
+		var animation = get_node("animation")
+		if animation:
+			if animation.is_playing():
+				return
+			animation.play("hide")
+
+	# XXX: What is this `look` node? A verb menu thing?
+	if has_node("look"):
+		get_node("look").set_pressed(false)
+
 	current_action = ""
+	hide()
 	print("inventory close")
 
 func toggle():
@@ -116,7 +125,7 @@ func _input(event):
 func log_button_pressed():
 	close()
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "open_log")
-	
+
 func _on_open_inventory_signal(open):
 	if (open):
 		open()

--- a/device/project.godot
+++ b/device/project.godot
@@ -60,6 +60,7 @@ singletons=[  ]
 inventory_toggle=[ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":5,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":7,"pressure":0.0,"pressed":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":9,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
  ]
 look=[ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":3,"pressure":0.0,"pressed":false,"script":null)
  ]


### PR DESCRIPTION
This is not complete yet, but opened to gather preliminary feedback. There is even a non- yet near-zero possibility I'll be committing to it today.

The inventory is very broken as it stands in master, and something like the in-game buttons are not documented in the book (#45 flossmanualsfr#15).

I can only guess at what the intentions originally were here and try to fix accordingly. For what it's worth, with these changes in, I can hit the tab key to open an inventory and complaints are benign instead of crashing everything.

I have not created the in-game buttons and would hope that the branch goes in as is now, or with minimal changes, and someone else fix the buttons without me. This is because I do not currently see a need to have the buttons in anything I'm working on and it's a huge distraction. If I change my mind, this would still be on IRC/#escoria or a new PR or wherever separate from this.

@fleskesvor I am happy to squash these if they pass inspection ;)
