### PR TITLE
Show in-game buttons is broken, remove it so Escoria does not crash

### DIFF
--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -43,25 +43,4 @@ func menu_closed():
 func _ready():
 	add_to_group("hud")
 	add_to_group("game")
-	#get_node("inv_toggle").connect("pressed", self, "inv_toggle")
-	#get_node("inv_toggle").set_focus_mode(Control.FOCUS_NONE)
-
-	#get_node("buttons").hide()
-	if ProjectSettings.get_setting("escoria/platform/show_ingame_buttons"):
-		if (not get_node("inv_toggle").is_hidden()):
-			get_node("buttons").show()
-
-		var p = get_parent().get_parent().get_parent()
-		for i in range(0, p.get_child_count()):
-			var c = p.get_child(i)
-			if (c is preload("res://globals/background.gd")):
-				background = c
-				break
-
-		get_node("inv_toggle").connect("visibility_changed",self,"_on_inv_toggle_vis_chaged")
-		get_node("buttons/hints").connect("pressed",self,"_on_hint_pressed")
-		get_node("buttons/menu").connect("pressed",self,"_on_menu_pressed")
-
-
-	set_tooltip("")
 

--- a/device/project.godot
+++ b/device/project.godot
@@ -39,7 +39,6 @@ platform/dialog_type_suffix=""
 platform/force_text_ids=false
 platform/exit_button=true
 platform/screen_resizable=true
-platform/show_ingame_buttons=false
 platform/telon="res://globals/telon.tscn"
 platform/window_title_height=32
 platform/use_custom_camera=true


### PR DESCRIPTION
IMO this code should all be removed and replaced with something under `doc/` on how to create in-game buttons if someone wants it.

@StraToN @fleskesvor what do you think? Should this just be replaced with documentation? Would you write it?