### PR TITLE
Fix automatic background area code

### DIFF
--- a/device/globals/background_area.gd
+++ b/device/globals/background_area.gd
@@ -1,11 +1,10 @@
-extends Area2D
+extends Sprite
 
 export var action = "walk"
-var collisionshape_click
-var rectangleshape
+var area
 
 func input(viewport, event, shape_idx):
-	if event.type == InputEvent.MOUSE_BUTTON && event.pressed:
+	if event is InputEventMouseButton and event.pressed:
 		if (event.button_index == BUTTON_LEFT):
 			get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "clicked", self, get_position() + event.position, event)
 		elif (event.button_index == BUTTON_RIGHT):
@@ -19,19 +18,26 @@ func _init():
 
 func _enter_tree():
 	# Use size of background texture to calculate collision shape
-	var background = get_parent().get_node("background")
-	if background:
-		var size = background.get_size()
-		var extents = Vector2(size.x / 2, size.y / 2)
-		var transform = Transform2D(Vector2(1, 0), Vector2(0, 1), extents)
+	var size = get_texture().get_size()
 
-		var shape = RectangleShape2D.new()
-		shape.set_extents(extents)
-		add_shape(shape)
-		set_shape_transform(0, transform)
+	area = Area2D.new()
+	var shape = RectangleShape2D.new()
+
+	var sid = area.create_shape_owner(area)
+
+	# Move origin of Area2D to center of Sprite
+	var transform = area.shape_owner_get_transform(sid)
+	transform.origin = size / 2
+	area.shape_owner_set_transform(sid, transform)
+
+	# Set extents of RectangleShape2D to cover entire Sprite
+	shape.set_extents(size / 2)
+	area.shape_owner_add_shape(sid, shape)
+
+	add_child(area)
 
 func _ready():
-	connect("gui_input", self, "input")
+	area.connect("input_event", self, "input")
 	add_to_group("background")
 
 func emit_right_click():

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -95,11 +95,13 @@ func clicked(obj, pos, input_event = null):
 
 	if input_event:
 		walk_context = {"fast": input_event.doubleclick}
-	# If multiple areas are clicked at once, an item_background "wins"
-	if obj is Area2D:
-		for area in obj.get_overlapping_areas():
+
+	# If an background_area is covered by an item, the item "wins"
+	if obj is preload("res://globals/background_area.gd"):
+		for area in obj.get_child(0).get_overlapping_areas():
 			if area.has_method("is_clicked") and area.is_clicked():
 				return
+
 	joystick_mode = false
 	if !vm.can_interact():
 		return

--- a/doc/background.md
+++ b/doc/background.md
@@ -1,0 +1,11 @@
+# Background
+
+The background node acts as a catch-all for input events. Any input event that isn't captured by another interactive element is processed by this node.
+
+To quickly add a background to your scene, add a `TextureRect` node as the first child of the `scene` node, name it "background" and add the `globals/background.gd` script.
+
+The drawback of this method, however, is that adding items to your scene with complex shapes becomes difficult, since you have to use `TextureButton`s with click masks, which have to be made with external drawing tools.
+
+For such use cases, the alternative is to use a `Sprite` for your background, name it "background", make sure the `Offset/Centered` property is not checked and add the `globals/background_area.gd` script.
+
+This enables you to use `Area2D` nodes for your items, which lets you draw one or more `CollisionPolygon2D` child node(s) to capture input, using only editor tools for the drawing. You can also add `Sprite` nodes as children of the `Area2D` item node if your items are not part of the background image.


### PR DESCRIPTION
This updates the automatic generation of a shape for the background when using a Sprite node to work with Godot 3, and also uses a Sprite instead of an Area2D to make it more similar to using a TextureRect node for the background. To make the process more straight-forward, the Area2D node is also generated from code, so these are the only steps required to use a background_area

1. create background Sprite and attach image
2. disable centering of Sprite node
3. attach background_area.gd script

Step 2 should probably be done automatically, but it will not be visible to the developer unless the script is made into a tool script, so maybe it's best to just document this.
