### PR TITLE
Setting to force disabling typewriter speech

### DIFF
--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -7,6 +7,7 @@ var total_time
 var character
 export var typewriter_text = true
 export var characters_per_second = 45.0
+var force_disable_typewriter_text = ProjectSettings.get_setting("escoria/platform/force_disable_typewriter_text")
 var finished = false
 var play_intro = true
 var play_outro = true
@@ -31,7 +32,7 @@ export var fixed_pos = false
 func _process(time):
 	if finished:
 		return
-	if !typewriter_text:
+	if force_disable_typewriter_text or !typewriter_text:
 		label.set_visible_characters(label.get_total_character_count())
 		text_done = true
 	elapsed += time

--- a/device/project.godot
+++ b/device/project.godot
@@ -37,6 +37,7 @@ platform/credits="res://demo/ui/credits/credits.txt"
 platform/dialog_option_height=1
 platform/dialog_type_suffix=""
 platform/force_text_ids=false
+platform/force_disable_typewriter_text=false
 platform/exit_button=true
 platform/screen_resizable=true
 platform/show_ingame_buttons=false


### PR DESCRIPTION
Because the actual variable is sort of convolutedly hidden, this makes configuration easier.