### PR TITLE
Variables to affect player speed

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -91,6 +91,10 @@ func set_current_tool(p_tool):
 	current_tool = p_tool
 
 func clicked(obj, pos, input_event = null):
+	var walk_context = null
+
+	if input_event:
+		walk_context = {"fast": input_event.doubleclick}
 	# If multiple areas are clicked at once, an item_background "wins"
 	if obj is Area2D:
 		for area in obj.get_overlapping_areas():
@@ -112,7 +116,7 @@ func clicked(obj, pos, input_event = null):
 			if player == self:
 				return
 			if (action_menu and !inventory.is_visible()) or !action_menu:
-				player.walk_to(pos)
+				player.walk_to(pos, walk_context)
 				# Leave the tooltip if the player is in eg. a "use key with" state
 				if !current_action:
 					get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip", "")
@@ -150,7 +154,7 @@ func clicked(obj, pos, input_event = null):
 			if player == self:
 				return
 			if (action_menu and !inventory.is_visible()) or !action_menu:
-				player.walk_to(pos)
+				player.walk_to(pos, walk_context)
 				# Leave the tooltip if the player is in eg. a "use key with" state
 				if !current_action:
 					get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip", "")
@@ -165,7 +169,7 @@ func clicked(obj, pos, input_event = null):
 						pos = obj.get_node("interact_pos").get_global_position()
 					else:
 						pos = obj.get_global_position()
-					player.walk_to(pos)
+					player.walk_to(pos, walk_context)
 			# Have to verify left button because `clicked` reacts to any click
 			elif input_event.button_index == BUTTON_LEFT:
 				spawn_action_menu(obj)

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -245,6 +245,8 @@ func _process(time):
 			next = walk_path[path_ofs]
 
 		var dist = speed * time * pow(last_scale.x, 2) * terrain.player_speed_multiplier
+		if walk_context and walk_context.fast:
+			dist *= terrain.player_doubleclick_speed_multiplier
 		var dir = (next - pos).normalized()
 
 		# assume that x^2 + y^2 == 1, apply v_speed_damp the y axis

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -1,4 +1,4 @@
-tool 
+tool
 
 extends Node2D
 
@@ -244,7 +244,7 @@ func _process(time):
 		else:
 			next = walk_path[path_ofs]
 
-		var dist = speed * time * last_scale.x * last_scale.x
+		var dist = speed * time * pow(last_scale.x, 2) * terrain.player_speed_multiplier
 		var dir = (next - pos).normalized()
 
 		# assume that x^2 + y^2 == 1, apply v_speed_damp the y axis

--- a/device/globals/terrain.gd
+++ b/device/globals/terrain.gd
@@ -9,6 +9,7 @@ export(int, "None", "Scales", "Lightmap") var debug_mode = 1 setget debug_mode_u
 export var lightmap_modulate = Color(1, 1, 1, 1)
 export var scale_min = 0.3
 export var scale_max = 1.0
+export var player_speed_multiplier = 1.0  # Override player speed in current scene
 var texture
 var img_area
 var _texture_dirty = false

--- a/device/globals/terrain.gd
+++ b/device/globals/terrain.gd
@@ -10,6 +10,7 @@ export var lightmap_modulate = Color(1, 1, 1, 1)
 export var scale_min = 0.3
 export var scale_max = 1.0
 export var player_speed_multiplier = 1.0  # Override player speed in current scene
+export var player_doubleclick_speed_multiplier = 1.5  # Make the player move faster when doubleclicked
 var texture
 var img_area
 var _texture_dirty = false


### PR DESCRIPTION
Because sometimes a scaled-down player sprite can take annoyingly long to cross the screen. By default the speed is not affected.

Also make double-clicking move the player faster, as is customary in modern adventure games. The default is a multiplier of 1.5.