### PR TITLE
[RFC] Camera zoom WIP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "device/game"]
+	path = device/game
+	url = git+ssh://git@github.com/mjtorn/escoria-proto-submodule

--- a/README.md
+++ b/README.md
@@ -22,7 +22,19 @@ to the backers of the Dog Mendonça Kickstarter campaign.
 
 ## Usage
 
-Here be dragons.
+Here be dragons. For https://github.com/mjtorn/escoria/tree/devel you want either
+
+    $ git clone https://github.com/mjtorn/escoria/ --recurse-submodules
+
+to see the code, but you have to `git checkout -b devel origin/devel` to see where the money at.
+
+Alternatively you can use
+
+    $ git clone https://github.com/mjtorn/escoria/ --recurse-submodules -b devel
+
+to get there by default.
+
+(These instructions shall never be merged to the upstream master!)
 
 ## Documentation
 

--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -31,6 +31,7 @@ var commands = {
 	"camera_set_target": { "min_args": 1, "types": [TYPE_REAL] },
 	"camera_set_pos": { "min_args": 3, "types": [TYPE_REAL, TYPE_INT, TYPE_INT] },
 	"camera_set_zoom_height": { "min_args": 1, "types": [TYPE_INT] },
+	"camera_unset_zoom": { "min_args": 0 },
 	"autosave": { "min_args": 0 },
 	"queue_resource": { "min_args": 1, "types": [TYPE_STRING, TYPE_BOOL] },
 	"queue_animation": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL] },

--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -30,6 +30,7 @@ var commands = {
 	"custom": { "min_args": 2 },
 	"camera_set_target": { "min_args": 1, "types": [TYPE_REAL] },
 	"camera_set_pos": { "min_args": 3, "types": [TYPE_REAL, TYPE_INT, TYPE_INT] },
+	"camera_set_zoom_height": { "min_args": 1, "types": [TYPE_INT] },
 	"autosave": { "min_args": 0 },
 	"queue_resource": { "min_args": 1, "types": [TYPE_STRING, TYPE_BOOL] },
 	"queue_animation": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL] },

--- a/device/globals/scene.gd
+++ b/device/globals/scene.gd
@@ -1,4 +1,12 @@
 extends "res://globals/scene_base.gd"
 
+export(int) var zoom_height_pixels
+
 func _ready():
-	pass
+	if !zoom_height_pixels:
+		zoom_height_pixels = get_viewport().size.y
+
+	vm = get_node("/root/vm")
+	vm.set_zoom_height(zoom_height_pixels)
+	printt("scene.gd set zoom_height ", zoom_height_pixels)
+

--- a/device/globals/scene.gd
+++ b/device/globals/scene.gd
@@ -3,10 +3,4 @@ extends "res://globals/scene_base.gd"
 export(int) var zoom_height_pixels
 
 func _ready():
-	if !zoom_height_pixels:
-		zoom_height_pixels = get_viewport().size.y
-
-	vm = get_node("/root/vm")
-	vm.set_zoom_height(zoom_height_pixels)
-	printt("scene.gd set zoom_height ", zoom_height_pixels)
-
+	pass

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -201,6 +201,10 @@ func camera_set_pos(params):
 	var pos = Vector2(params[1], params[2])
 	vm.camera_set_target(speed, pos)
 
+func camera_set_zoom_height(params):
+	var height = params[0]
+	vm.set_zoom_height(height)
+
 func set_globals(params):
 	var pat = params[0]
 	var val = params[1]

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -100,7 +100,7 @@ func inventory_add(params):
 func inventory_remove(params):
 	vm.inventory_set(params[0], false)
 	return vm.state_return
-	
+
 func inventory_open(params):
 	vm.emit_signal("open_inventory", params[0])
 
@@ -196,7 +196,7 @@ func camera_set_target(params):
 		targets.push_back(params[i])
 	vm.camera_set_target(speed, targets)
 
-func camera_set_position(params):
+func camera_set_pos(params):
 	var speed = params[0]
 	var pos = Vector2(params[1], params[2])
 	vm.camera_set_target(speed, pos)

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -205,6 +205,9 @@ func camera_set_zoom_height(params):
 	var height = params[0]
 	vm.set_zoom_height(height)
 
+func camera_unset_zoom(params):
+	vm.unset_zoom()
+
 func set_globals(params):
 	var pat = params[0]
 	var val = params[1]

--- a/device/project.godot
+++ b/device/project.godot
@@ -84,4 +84,4 @@ use=[ Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_na
 
 [locale]
 
-translations=PoolStringArray( "res://translations/general.en.translation", "res://translations/general.es.translation", "res://translations/general.fr.translation" )
+translations=PoolStringArray( "res://game/translations/general.en.translation", "res://game/translations/general.es.translation", "res://game/translations/general.fr.translation" )

--- a/device/project.godot
+++ b/device/project.godot
@@ -10,8 +10,8 @@ config_version=3
 
 [application]
 
-config/name="Prototype"
-run/main_scene="res://globals/scene_main.tscn"
+config/name="Prototype / Submodule"
+run/main_scene="res://game/rooms/001.office/main.tscn"
 
 [autoload]
 
@@ -29,27 +29,27 @@ window/size/test_height=1080
 
 application/max_voice_volume=2
 application/save_data="res://globals/save_data.gd"
-application/speech_suffix=".spx"
+application/speech_suffix=".ogg"
 application/tooltip_lang_default="en"
-application/speech_path="res://demo/audio/speech/"
+application/speech_path="res://audio/speech/"
 platform/action_menu_scale=2
 platform/credits="res://demo/ui/credits/credits.txt"
 platform/dialog_option_height=1
 platform/dialog_type_suffix=""
-platform/force_text_ids=false
-platform/force_disable_typewriter_text=false
+platform/force_text_ids=true
+platform/force_disable_typewriter_text=true
 platform/exit_button=true
-platform/screen_resizable=true
+platform/screen_resizable=false
 platform/telon="res://globals/telon.tscn"
 platform/window_title_height=32
 platform/use_custom_camera=true
 ui/credits=""
 ui/in_game_menu="res://ui/in_game_menu.tscn"
-ui/main_menu="res://demo/ui/main_menu.tscn"
-ui/confirm_popup="res://demo/ui/confirm_popup.tscn"
+ui/main_menu="res://ui/main_menu.tscn"
+ui/confirm_popup="res://ui/confirm_popup.tscn"
 ui/savegames=""
-ui/tooltip_follows_mouse=false
-ui/right_mouse_button_action_menu=false
+ui/tooltip_follows_mouse=true
+ui/right_mouse_button_action_menu=true
 
 [gdnative]
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://globals/hud.gd" type="Script" id=1]
 [ext_resource path="res://game/ui/inventory.tscn" type="PackedScene" id=2]
 
-[node name="hud" type="Control"]
+[node name="hud" type="Control" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -12,13 +12,13 @@ anchor_bottom = 0.0
 margin_right = 40.0
 margin_bottom = 40.0
 rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
 mouse_filter = 0
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 script = ExtResource( 1 )
 
-[node name="tooltip" type="Label" parent="."]
+[node name="tooltip" type="Label" parent="." index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -29,8 +29,8 @@ margin_top = 58.0
 margin_right = 1149.0
 margin_bottom = 115.0
 rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
 mouse_filter = 2
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
@@ -40,10 +40,12 @@ percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="inventory" parent="." instance=ExtResource( 2 )]
+[node name="inventory" parent="." index="1" instance=ExtResource( 2 )]
 
+visible = false
 margin_left = 702.0
 margin_top = 457.0
 margin_right = 742.0
 margin_bottom = 497.0
+
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -2,7 +2,6 @@
 
 [ext_resource path="res://globals/hud.gd" type="Script" id=1]
 [ext_resource path="res://demo/ui/inventory.tscn" type="PackedScene" id=2]
-[ext_resource path="res://demo/ui/verb_menu.tscn" type="PackedScene" id=3]
 
 [node name="hud" type="Control"]
 
@@ -47,12 +46,4 @@ margin_left = 702.0
 margin_top = 457.0
 margin_right = 742.0
 margin_bottom = 497.0
-
-[node name="verb_menu" parent="." instance=ExtResource( 3 )]
-
-margin_left = 63.0
-margin_top = 519.0
-margin_right = 103.0
-margin_bottom = 559.0
-
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://globals/hud.gd" type="Script" id=1]
-[ext_resource path="res://demo/ui/inventory.tscn" type="PackedScene" id=2]
+[ext_resource path="res://game/ui/inventory.tscn" type="PackedScene" id=2]
 
 [node name="hud" type="Control"]
 


### PR DESCRIPTION
It would be useful to have a feature where the camera can zoom in. Say there's a conversation going, the camera could be set to zoom in on the characters on `:talk`.

Another use case is that the character walks somewhere and the camera pushes in on a close-up, and when the character walks back out, the camera pulls out.

I think there could technically be other cameras, but with only one visible at any time and limited support in ESC scripts, surely it'd be more pain to deal with. And those cameras need to zoom as well.

After some struggling, I sort of got zooming to work, but didn't realize in advance that scaling the viewport causes the action menu (and all that, tooltips etc) to get zoomed as well! There must be a better way!

Is there a way to filter out the HUD and dialog stuff and scale them down when scaling the viewport up? Does that question make sense? It should be easier than tagging all the TextureRects and sub-scene nodes with `affected_by_zoom` or whatever.

I've been asking around on IRC and searching online for a while, but no evident answer has popped up.

For some reason `camera.zoom = ...` has had no impact, does this work for anyone?

This branch is off my devel branch, which has apparently deviated a lot from master. Sorry. It is not meant to be merged, but to be discussed, though I did hope the commit history would be cleaner. Pay no attention to the commits older than 2018-03-02 ;) (I may sort my devel branch later and force-push it)

You can check out the `gh-mjtorn-devel-zoom` branch and update the submodule, I set it up so it points to a corresponding branch in my prototype submodule. It includes buttons for changing the zoom level to play around with. Unfortunately the TextureRects I used are white, as the background, so they are a bit awkward to find, but `look`ing at them changes the zoom. That means the camera zoom functionality is properly exported in the ESC scripts, so that's at least something.

The relevant HEAD in my prototype submodule is 7e27cdafe176e6405780680c4bda3832b9e952f3 (branch `room.002.zoom`.
