### PR TITLE
Make cache system explicit

### DIFF
--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -25,7 +25,6 @@ var commands = {
 	"%": { "alias": "label", "min_args": 1},
 	"jump": { "min_args": 1 },
 	"dialog_config": { "min_args": 3, "types": [TYPE_STRING, TYPE_BOOL, TYPE_BOOL] },
-	"queue_scene": { "min_args": 1 },
 	"sched_event": { "min_args": 3, "types": [TYPE_REAL, TYPE_STRING, TYPE_STRING] },
 	"custom": { "min_args": 2 },
 	"camera_set_target": { "min_args": 1, "types": [TYPE_REAL] },

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -402,6 +402,8 @@ func finished(context):
 	context.waiting = false
 
 func change_scene(params, context):
+	# It might be tempting to use `get_tree().change_scene(params[0])`,
+	# but this custom solution is safer around your scene structure
 	printt("change scene to ", params[0])
 	#var res = ResourceLoader.load(params[0])
 	check_cache()
@@ -469,6 +471,10 @@ func autosave_done(err):
 	last_autosave = OS.get_ticks_msec()
 
 func check_cache():
+	# Warm the cache from the hard-coded list, unless configured to skip
+	if ProjectSettings.get_setting("escoria/platform/skip_cache"):
+		return
+
 	for s in scenes_cache_list:
 		if s in scenes_cache:
 			continue
@@ -695,10 +701,10 @@ func _ready():
 	level.set_vm(self)
 	game_size = get_viewport().size
 
-	scenes_cache_list.push_back(ProjectSettings.get_setting("escoria/platform/telon"))
-	scenes_cache_list.push_back(get_hud_scene())
+	if !ProjectSettings.get_setting("escoria/platform/skip_cache"):
+		scenes_cache_list.push_back(ProjectSettings.get_setting("escoria/platform/telon"))
+		scenes_cache_list.push_back(get_hud_scene())
 
-	if !ProjectSettings.has_method("debug/skip_cache") || !ProjectSettings.get_setting("debug/skip_cache"):
 		printt("cache list ", scenes_cache_list)
 		for s in scenes_cache_list:
 			print("s is ", s)

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -422,16 +422,6 @@ func change_scene(params, context):
 	camera_set_target(0, null)
 	autosave_pending = true
 
-func swap_scene(p_path):
-
-	var res = res_cache.get_resource(p_path)
-	main.clear_scene()
-	var scene = res.instance()
-	if scene:
-		main.set_scene(scene)
-	else:
-		report_errors("", ["Failed loading scene "+p_path+" for swap_scene"])
-
 func spawn(params):
 	var res = ResourceLoader.load(params[0])
 	var scene = res.instance()

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -100,7 +100,7 @@ func inventory_add(params):
 func inventory_remove(params):
 	vm.inventory_set(params[0], false)
 	return vm.state_return
-	
+
 func inventory_open(params):
 	vm.emit_signal("open_inventory", params[0])
 
@@ -152,9 +152,6 @@ func change_scene(params):
 
 	current_context.waiting = true
 	return vm.state_yield
-
-func queue_scene(params):
-	vm.res_cache.queue_resource(params[0])
 
 func spawn(params):
 	return vm.spawn(params)

--- a/device/project.godot
+++ b/device/project.godot
@@ -32,6 +32,7 @@ application/save_data="res://globals/save_data.gd"
 application/speech_suffix=".spx"
 application/tooltip_lang_default="en"
 application/speech_path="res://demo/audio/speech/"
+platform/skip_cache=false
 platform/action_menu_scale=2
 platform/credits="res://demo/ui/credits/credits.txt"
 platform/dialog_option_height=1


### PR DESCRIPTION
This is the most likely cause for Heisenbugs and waste of time while developing something else. It was not even widely used.

Godot should take care of loading well enough without reinventing any wheels. Modern computers are fast. Kernels have file system caches. There are probably even more reasons why not to overcomplicate things.

Therefore, to simplify the code and to make caching-related bugs impossible, throw it out.

No perceptible difference in performance and the demo test scene works as expected.

The commits are split into smaller pieces if that makes discussion easier, and although I hope this history can be merged as-is, I can - of course - also squash them.
