### PR TITLE
Camera zoom + Action menu from project settings

### DIFF
--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -30,6 +30,8 @@ var commands = {
 	"custom": { "min_args": 2 },
 	"camera_set_target": { "min_args": 1, "types": [TYPE_REAL] },
 	"camera_set_pos": { "min_args": 3, "types": [TYPE_REAL, TYPE_INT, TYPE_INT] },
+	"camera_zoom_in": { "min_args": 1, "types": [TYPE_REAL] },
+	"camera_zoom_out": { "min_args": 0 },
 	"autosave": { "min_args": 0 },
 	"queue_resource": { "min_args": 1, "types": [TYPE_STRING, TYPE_BOOL] },
 	"queue_animation": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL] },

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -384,8 +384,13 @@ func load_hud():
 func _ready():
 	add_to_group("game")
 	player = get_node("../player")
-	if has_node("action_menu"):
-		action_menu = get_node("action_menu")
+
+	# Add action menu to hud layer if found in project settings
+	if ProjectSettings.get_setting("escoria/ui/action_menu"):
+		action_menu = load(ProjectSettings.get_setting("escoria/ui/action_menu")).instance()
+		if action_menu and action_menu is preload("res://globals/action_menu.gd"):
+			$hud_layer.add_child(action_menu)
+
 	if fallbacks_path != "":
 		fallbacks = vm.compile(fallbacks_path)
 

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -64,6 +64,9 @@ var scenes_cache = {} # this will eventually have everything in scenes_cache_lis
 
 var settings
 
+# Used to save scale of current scene so that we can reset zoom
+var _original_scale
+
 func save_settings():
 	save_data.save_settings(settings, null)
 
@@ -161,6 +164,19 @@ func update_camera(time):
 	t[2] = (-(pos - half))
 
 	get_node("/root").set_canvas_transform(t)
+
+func camera_zoom_in(magnitude):
+	var current_scene = main.get_current_scene()
+	if current_scene == null or not current_scene is preload("res://globals/scene.gd"):
+		return
+	# Save current scale so that we can reset zoom
+	_original_scale = current_scene.scale
+	current_scene.scale = _original_scale * Vector2(magnitude, magnitude)
+
+func camera_zoom_out():
+	var current_scene = main.get_current_scene()
+	if current_scene and current_scene is preload("res://globals/scene.gd") and _original_scale:
+		current_scene.scale = _original_scale
 
 func _adjust_camera(pos):
 	var half = game_size / 2

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -64,8 +64,8 @@ var scenes_cache = {} # this will eventually have everything in scenes_cache_lis
 
 var settings
 
-# Used to save scale of current scene so that we can reset zoom
-var _original_scale
+# Keep previous states on a stack to revert zoom
+var _zoom_stack = []
 
 func save_settings():
 	save_data.save_settings(settings, null)
@@ -167,16 +167,16 @@ func update_camera(time):
 
 func camera_zoom_in(magnitude):
 	var current_scene = main.get_current_scene()
-	if current_scene == null or not current_scene is preload("res://globals/scene.gd"):
-		return
-	# Save current scale so that we can reset zoom
-	_original_scale = current_scene.scale
-	current_scene.scale = _original_scale * Vector2(magnitude, magnitude)
+	if current_scene and current_scene is preload("res://globals/scene.gd"):
+		# Save current state so that we can reset zoom
+		_zoom_stack.append({"scale": current_scene.scale})
+		current_scene.scale *= Vector2(magnitude, magnitude)
 
 func camera_zoom_out():
 	var current_scene = main.get_current_scene()
-	if current_scene and current_scene is preload("res://globals/scene.gd") and _original_scale:
-		current_scene.scale = _original_scale
+	var prev_state = _zoom_stack.pop_back()
+	if current_scene and current_scene is preload("res://globals/scene.gd") and prev_state:
+		current_scene.scale = prev_state["scale"]
 
 func _adjust_camera(pos):
 	var half = game_size / 2

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -44,3 +44,6 @@ func _ready():
 	add_to_group("hud")
 	add_to_group("game")
 
+	# Hide verb menu if hud layer has an action menu
+	if has_node("../action_menu"):
+		$verb_menu.hide()

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -201,6 +201,13 @@ func camera_set_position(params):
 	var pos = Vector2(params[1], params[2])
 	vm.camera_set_target(speed, pos)
 
+func camera_zoom_in(params):
+	var magnitude = params[0]
+	vm.camera_zoom_in(magnitude)
+
+func camera_zoom_out(params):
+	vm.camera_zoom_out()
+
 func set_globals(params):
 	var pat = params[0]
 	var val = params[1]

--- a/device/project.godot
+++ b/device/project.godot
@@ -49,6 +49,7 @@ ui/confirm_popup="res://demo/ui/confirm_popup.tscn"
 ui/savegames=""
 ui/tooltip_follows_mouse=false
 ui/right_mouse_button_action_menu=false
+ui/action_menu=""
 
 [gdnative]
 


### PR DESCRIPTION
Enable zooming of game scene with esc commands by changing scale. An array is used to save previous scales so that one can easily revert to previous scales.

To make action menu unaffected by zoom, it needs to be added to the hud layer instead of as a direct child of the game node, so a project settings property is exposed which is used to instance the action menu from code, and also hide the verb menu if an action menu is found.