### PR TITLE
Camera zoom with HUD extensions

### DIFF
--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -30,6 +30,8 @@ var commands = {
 	"custom": { "min_args": 2 },
 	"camera_set_target": { "min_args": 1, "types": [TYPE_REAL] },
 	"camera_set_pos": { "min_args": 3, "types": [TYPE_REAL, TYPE_INT, TYPE_INT] },
+	"camera_zoom_in": { "min_args": 1, "types": [TYPE_REAL] },
+	"camera_zoom_out": { "min_args": 0 },
 	"autosave": { "min_args": 0 },
 	"queue_resource": { "min_args": 1, "types": [TYPE_STRING, TYPE_BOOL] },
 	"queue_animation": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL] },

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -372,7 +372,15 @@ func set_camera_limits():
 func load_hud():
 	var hres = vm.res_cache.get_resource(vm.get_hud_scene())
 	get_node("hud_layer/hud").replace_by_instance(hres)
-	inventory = get_node("hud_layer/hud/inventory")
+
+	# Add inventory to hud layer, usually hud_minimal.tscn, if found in project settings
+	if !$hud_layer.has_node("inventory") and ProjectSettings.get_setting("escoria/ui/inventory"):
+		inventory = load(ProjectSettings.get_setting("escoria/ui/inventory")).instance()
+		if inventory and inventory is preload("res://globals/inventory.gd"):
+			inventory.hide()
+			$hud_layer.add_child(inventory)
+	else:
+		inventory = get_node("hud_layer/hud/inventory")
 
 	# Add action menu to hud layer if found in project settings
 	if ProjectSettings.get_setting("escoria/ui/action_menu"):

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -180,8 +180,8 @@ func spawn_action_menu(obj):
 		return
 	action_menu.show()
 	var pos
-	pos = obj.get_global_mouse_position()
-	action_menu.set_position(pos)
+	pos = get_viewport().get_mouse_position()
+	action_menu.position = pos
 	action_menu.start(obj)
 	#obj.grab_focus()
 
@@ -374,6 +374,12 @@ func load_hud():
 	get_node("hud_layer/hud").replace_by_instance(hres)
 	inventory = get_node("hud_layer/hud/inventory")
 
+	# Add action menu to hud layer if found in project settings
+	if ProjectSettings.get_setting("escoria/ui/action_menu"):
+		action_menu = load(ProjectSettings.get_setting("escoria/ui/action_menu")).instance()
+		if action_menu and action_menu is preload("res://globals/action_menu.gd"):
+			$hud_layer.add_child(action_menu)
+
 	#if inventory_enabled:
 	#	get_node("hud_layer/hud/inv_toggle").show()
 	#else:
@@ -384,8 +390,7 @@ func load_hud():
 func _ready():
 	add_to_group("game")
 	player = get_node("../player")
-	if has_node("action_menu"):
-		action_menu = get_node("action_menu")
+
 	if fallbacks_path != "":
 		fallbacks = vm.compile(fallbacks_path)
 

--- a/device/globals/game_am.tscn
+++ b/device/globals/game_am.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://globals/game.gd" type="Script" id=1]
+[ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=2]
+
+[node name="game" type="Node"]
+
+script = ExtResource( 1 )
+fallbacks_path = "res://demo/fallbacks.esc"
+inventory_enabled = true
+camera_limits = Rect2( 0, 0, 0, 0 )
+
+[node name="dialog_player" parent="." index="0" instance=ExtResource( 2 )]
+
+[node name="hud_layer" type="CanvasLayer" parent="." index="1"]
+
+layer = 1
+offset = Vector2( 0, 0 )
+rotation = 0.0
+scale = Vector2( 1, 1 )
+
+[node name="hud" parent="hud_layer" index="0" instance_placeholder="res://ui/hud_minimal.tscn"]
+
+[node name="wait_timer" type="Timer" parent="." index="2"]
+
+process_mode = 1
+wait_time = 1.0
+one_shot = false
+autostart = false
+
+[node name="camera" type="Camera2D" parent="." index="3"]
+
+anchor_mode = 1
+rotating = false
+current = true
+zoom = Vector2( 1, 1 )
+limit_left = -10000000
+limit_top = -10000000
+limit_right = 10000000
+limit_bottom = 10000000
+limit_smoothed = false
+drag_margin_h_enabled = true
+drag_margin_v_enabled = true
+smoothing_enabled = false
+smoothing_speed = 5.0
+drag_margin_left = 0.2
+drag_margin_top = 0.2
+drag_margin_right = 0.2
+drag_margin_bottom = 0.2
+editor_draw_screen = true
+editor_draw_limits = false
+editor_draw_drag_margin = false
+
+

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -695,7 +695,7 @@ func _rate_game():
 	OS.shell_open(rate_url)
 
 func get_hud_scene():
-	var hpath = "res://ui/hud.tscn"
+	var hpath = ProjectSettings.get_setting("escoria/ui/hud")
 	return hpath
 
 func _ready():

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -64,6 +64,9 @@ var scenes_cache = {} # this will eventually have everything in scenes_cache_lis
 
 var settings
 
+# Used to save scale of current scene so that we can reset zoom
+var _original_scale
+
 func save_settings():
 	save_data.save_settings(settings, null)
 
@@ -161,6 +164,19 @@ func update_camera(time):
 	t[2] = (-(pos - half))
 
 	get_node("/root").set_canvas_transform(t)
+
+func camera_zoom_in(magnitude):
+	var current_scene = main.get_current_scene()
+	if current_scene == null or not current_scene is preload("res://globals/scene.gd"):
+		return
+	# Save current scale so that we can reset zoom
+	_original_scale = current_scene.scale
+	current_scene.scale = _original_scale * Vector2(magnitude, magnitude)
+
+func camera_zoom_out():
+	var current_scene = main.get_current_scene()
+	if current_scene and current_scene is preload("res://globals/scene.gd") and _original_scale:
+		current_scene.scale = _original_scale
 
 func _adjust_camera(pos):
 	var half = game_size / 2

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -64,8 +64,8 @@ var scenes_cache = {} # this will eventually have everything in scenes_cache_lis
 
 var settings
 
-# Used to save scale of current scene so that we can reset zoom
-var _original_scale
+# Keep previous states on a stack to revert zoom
+var _zoom_stack = []
 
 func save_settings():
 	save_data.save_settings(settings, null)
@@ -167,16 +167,16 @@ func update_camera(time):
 
 func camera_zoom_in(magnitude):
 	var current_scene = main.get_current_scene()
-	if current_scene == null or not current_scene is preload("res://globals/scene.gd"):
-		return
-	# Save current scale so that we can reset zoom
-	_original_scale = current_scene.scale
-	current_scene.scale = _original_scale * Vector2(magnitude, magnitude)
+	if current_scene and current_scene is preload("res://globals/scene.gd"):
+		# Save current state so that we can reset zoom
+		_zoom_stack.append({"scale": current_scene.scale})
+		current_scene.scale *= Vector2(magnitude, magnitude)
 
 func camera_zoom_out():
 	var current_scene = main.get_current_scene()
-	if current_scene and current_scene is preload("res://globals/scene.gd") and _original_scale:
-		current_scene.scale = _original_scale
+	var prev_state = _zoom_stack.pop_back()
+	if current_scene and current_scene is preload("res://globals/scene.gd") and prev_state:
+		current_scene.scale = prev_state["scale"]
 
 func _adjust_camera(pos):
 	var half = game_size / 2

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -44,3 +44,6 @@ func _ready():
 	add_to_group("hud")
 	add_to_group("game")
 
+	# Hide verb menu if hud layer has an action menu
+	if has_node("../action_menu"):
+		$verb_menu.hide()

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -201,6 +201,13 @@ func camera_set_position(params):
 	var pos = Vector2(params[1], params[2])
 	vm.camera_set_target(speed, pos)
 
+func camera_zoom_in(params):
+	var magnitude = params[0]
+	vm.camera_zoom_in(magnitude)
+
+func camera_zoom_out(params):
+	vm.camera_zoom_out()
+
 func set_globals(params):
 	var pat = params[0]
 	var val = params[1]

--- a/device/project.godot
+++ b/device/project.godot
@@ -49,6 +49,7 @@ ui/confirm_popup="res://demo/ui/confirm_popup.tscn"
 ui/savegames=""
 ui/tooltip_follows_mouse=false
 ui/right_mouse_button_action_menu=false
+ui/action_menu=""
 
 [gdnative]
 

--- a/device/project.godot
+++ b/device/project.godot
@@ -42,6 +42,7 @@ platform/exit_button=true
 platform/screen_resizable=true
 platform/telon="res://globals/telon.tscn"
 platform/window_title_height=32
+ui/hud="res://ui/hud.tscn"
 ui/credits=""
 ui/in_game_menu="res://ui/in_game_menu.tscn"
 ui/main_menu="res://demo/ui/main_menu.tscn"
@@ -50,6 +51,7 @@ ui/savegames=""
 ui/tooltip_follows_mouse=false
 ui/right_mouse_button_action_menu=false
 ui/action_menu=""
+ui/inventory=""
 
 [gdnative]
 

--- a/device/ui/hud_minimal.tscn
+++ b/device/ui/hud_minimal.tscn
@@ -1,0 +1,41 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://globals/hud.gd" type="Script" id=1]
+
+[node name="hud" type="Control"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 40.0
+margin_bottom = 40.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 0
+size_flags_horizontal = 2
+size_flags_vertical = 2
+script = ExtResource( 1 )
+
+[node name="tooltip" type="Label" parent="."]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 160.0
+margin_top = 58.0
+margin_right = 1149.0
+margin_bottom = 115.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 2
+size_flags_horizontal = 2
+size_flags_vertical = 0
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+align = 1
+valign = 1
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+

--- a/doc/hud.md
+++ b/doc/hud.md
@@ -1,0 +1,58 @@
+# HUD
+
+The HUD layer contains the tooltip, the verb or action menu and the inventory.
+
+By default Escoria is configured to use an "old-school SCUMM" layout, with a verb
+menu to the bottom-left side and the inventory to the bottom-right.
+
+An alternative HUD is provided as well, `ui/hud_minimal.tscn`.
+
+This documentation exists because of some limitations in how Godot's scenes work.
+
+Caveat: verb and action menus are incompatible. You will experience problems if you
+use a verb menu and configure an action menu in your settings. You have been warned!
+
+## Customizing the verb menu
+
+First you'll have to make a copy of `device/globals/game.tscn` to `game/game.tscn`
+so you can replace the placeholder HUD. Remember that the HUD contains the verb menu.
+
+Then you create a verb menu to your liking. You may copy `device/demo/ui/verb_menu.tscn`
+to `game/ui/verb_menu.tscn` and use it as your base. Hook this up in `game/game.tscn`
+
+Use your `game/game.tscn` as your bottom-most node in the scene tree.
+
+Last you'll have to copy `device/ui/hud.tscn` to `game/ui/hud.tscn`. Alter it to
+use your new verb menu.
+
+Adapting the steps above, you may also replace the inventory in your HUD.
+
+You can configure which HUD to use in the project settings. The path is
+`Escoria -> Ui -> Hud`.
+
+If you want something completely unique to your needs, you may create a completely
+new HUD scene in your `game/ui/` directory and configure the settings accordingly.
+This is in case you don't want an inventory at all or want something new in your
+HUD.
+
+From there on you may also create a unique-to-your-needs copy of the `hud.gd`
+script and use it in your HUD scene.
+
+## Making games with an action menu
+
+By action menu we mean a "new-school SCUMM" menu, also known as a "verb coin".
+
+Since Escoria uses the "old-school SCUMM" UI layout, with a verb menu, it is
+visible as a placeholder even when you don't want it. Let's address that.
+
+The first step is to add `game_am.tscn` instead of `game.tscn` as your lowermost
+node in the scene tree. This does not contain the verb-menu placeholder.
+
+Second you'll want to configure `Escoria -> Ui -> Hud` use `res://ui/hud_minimal.tscn`.
+
+Your action menu is a scene like any other. Create it as `device/game/ui/action_menu.tscn`
+and configure it into `Escoria -> Ui -> Action Menu`.
+
+The inventory is also a scene. You may take example from `device/demo/ui/inventory.tscn`
+and place it in `device/game/ui/inventory.tscn`. Configure it in `Escoria -> Ui -> Inventory`.
+


### PR DESCRIPTION
This builds on #79 

It fixes a bug where the action menu was opened in the wrong coordinates.

It also contains work to not have a verb menu in a game that uses an action menu.

It does not break the demo test scene.

It introduces settings for which hud to use and also the ability to change the inventory.

I'm more than happy that this allowed me to get rid of all my editing of `hud.tscn`, a major win in separating the framework from the game being developed :)

The problem was that the verb menu was really hard to get rid of. Even now there is a placholder in `game.tscn`, which is annoying, but must remain for now. The branch is getting out of control and the annoyance is so small, that for the time being, it would be most efficient to merge this branch.

Notes for the future: if Escoria becomes an asset, at least Unity assets may have a startup wizard for configuration. The placeholder verb menu may be dealt with before "assetifying", but latest then, the user should be able to set things up appropriately for the game.

@fleskesvor wanna hit merge?
