### PR TITLE
Zoom height

### DIFF
--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -29,6 +29,7 @@ var commands = {
 	"custom": { "min_args": 2 },
 	"camera_set_target": { "min_args": 1, "types": [TYPE_REAL] },
 	"camera_set_pos": { "min_args": 3, "types": [TYPE_REAL, TYPE_INT, TYPE_INT] },
+	"camera_set_zoom_height": { "min_args": 1, "types": [TYPE_INT] },
 	"camera_zoom_in": { "min_args": 1, "types": [TYPE_REAL] },
 	"camera_zoom_out": { "min_args": 0 },
 	"autosave": { "min_args": 0 },

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -165,6 +165,10 @@ func update_camera(time):
 
 	get_node("/root").set_canvas_transform(t)
 
+func camera_set_zoom_height(zoom_height):
+	var scale = game_size.y / zoom_height
+	camera_zoom_in(scale)
+
 func camera_zoom_in(magnitude):
 	var current_scene = main.get_current_scene()
 	if current_scene and current_scene is preload("res://globals/scene.gd"):

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -193,7 +193,7 @@ func camera_set_target(params):
 		targets.push_back(params[i])
 	vm.camera_set_target(speed, targets)
 
-func camera_set_position(params):
+func camera_set_pos(params):
 	var speed = params[0]
 	var pos = Vector2(params[1], params[2])
 	vm.camera_set_target(speed, pos)

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -198,6 +198,10 @@ func camera_set_pos(params):
 	var pos = Vector2(params[1], params[2])
 	vm.camera_set_target(speed, pos)
 
+func camera_set_zoom_height(params):
+	var height = params[0]
+	vm.camera_set_zoom_height(height)
+
 func camera_zoom_in(params):
 	var magnitude = params[0]
 	vm.camera_zoom_in(magnitude)


### PR DESCRIPTION
This PR introduces an ESC command to set the zoom in height pixels.

It also fixes the bug when the player is standing on a sizemap and a zoom happens, now the sprite is scaled as well.

I threw in a fix for the `set_camera_pos` command for good measure, it must have been broken by the big regexp change way back.

@fleskesvor wanna confirm this is fine?
