### PR TITLE
Made Files easier 3-11-18

### DIFF
--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -699,7 +699,7 @@ func _ready():
 	save_data = load(ProjectSettings.get_setting("escoria/application/save_data")).new()
 	save_data.start()
 
-	get_tree().set_auto_accept_quit(false)
+	get_tree().set_auto_accept_quit(ProjectSettings.get_setting("escoria/ui/force_quit"))
 	randomize()
 	add_user_signal("music_volume_changed")
 	add_user_signal("paused", ["p_paused"])

--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -4,7 +4,7 @@ extends "res://globals/interactive.gd"
 
 export var tooltip = ""
 export var action = ""
-export(String, FILE) var events_path = ""
+export(String, FILE,".esc") var events_path = ""
 export var global_id = ""
 export var use_combine = false
 export var inventory = false

--- a/device/globals/scene_base.gd
+++ b/device/globals/scene_base.gd
@@ -1,6 +1,6 @@
 extends Node
 
-export(String, FILE) var events_path = ""
+export(String, FILE,".esc") var events_path = ""
 
 func _ready():
 	main.call_deferred("set_current_scene", self, events_path)

--- a/device/project.godot
+++ b/device/project.godot
@@ -10,7 +10,7 @@ config_version=3
 
 [application]
 
-config/name="Prototype"
+config/name="Escoria_Prototype"
 run/main_scene="res://globals/scene_main.tscn"
 
 [autoload]
@@ -36,7 +36,6 @@ platform/skip_cache=false
 platform/action_menu_scale=2
 platform/credits="res://demo/ui/credits/credits.txt"
 platform/dialog_option_height=1
-platform/dialog_type_suffix=""
 platform/force_text_ids=false
 platform/force_disable_typewriter_text=false
 platform/exit_button=true
@@ -53,6 +52,8 @@ ui/tooltip_follows_mouse=false
 ui/right_mouse_button_action_menu=false
 ui/action_menu=""
 ui/inventory=""
+ui/force_quit=true
+platform/dialog_type_suffix=""
 
 [gdnative]
 


### PR DESCRIPTION
In Global_VM:

-  Added Force_Quit in project settings (You can now leave via the window's X button)

In Item.gd and scene_base.gd:
 

- added '.esc' to export(String,FILE) variables

Concept: 
 

- Tried making in game/editor Escoria syntax highlighter. For easier developer use.