### PR TITLE
Fix dealing with a clamped camera that tries to move

### DIFF
--- a/device/globals/dialog_player.gd
+++ b/device/globals/dialog_player.gd
@@ -11,7 +11,7 @@ func say(params, callback):
 	type = type + ProjectSettings.get_setting("escoria/platform/dialog_type_suffix")
 	var inst = get_resource(type).instance()
 	var z = inst.get_z_index()
-	get_tree().get_root().get_child(0).add_child(inst)
+	get_node("/root").get_child(0).add_child(inst)
 	var intro = true
 	var outro = true
 	if type in types:

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -161,9 +161,9 @@ func update_camera(time):
 	var half = game_size / 2
 	pos = _adjust_camera(pos)
 	var t = Transform2D()
-	t[2] = (-(pos - half))
+	t.origin = (-(pos - half))
 
-	get_node("/root").set_canvas_transform(t)
+	get_node("/root").canvas_transform = t
 
 func camera_set_zoom_height(zoom_height):
 	var scale = game_size.y / zoom_height

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -17,8 +17,7 @@ func clear_scene():
 	if current == null:
 		return
 
-	var root = get_tree().get_root()
-	root.remove_child(current)
+	get_node("/root").remove_child(current)
 	current.free()
 	current = null
 
@@ -28,8 +27,7 @@ func set_scene(p_scene):
 
 	if !p_scene:
 		return
-	var root = get_tree().get_root()
-	root.add_child(p_scene)
+	get_node("/root").add_child(p_scene)
 	set_current_scene(p_scene)
 
 func get_current_scene():
@@ -76,8 +74,7 @@ func menu_collapse():
 func set_current_scene(p_scene, events_path=null):
 	#print_stack()
 	current = p_scene
-	var root = get_tree().get_root()
-	root.move_child(p_scene, 0)
+	get_node("/root").move_child(p_scene, 0)
 
 	if events_path:
 		vm.load_file(events_path)
@@ -100,13 +97,13 @@ func check_screen():
 
 	var rate = float(vs.x)/float(vs.y)
 	var height = int(game_size.x / rate)
-	get_tree().get_root().set_size_override(true,Vector2(game_size.x,height))
-	get_tree().get_root().set_size_override_stretch(true)
+	get_node("/root").set_size_override(true,Vector2(game_size.x,height))
+	get_node("/root").set_size_override_stretch(true)
 
 	var m = Transform2D()
 	var ofs = Vector2(0, (height - game_size.y) / 2)
-	m[2] = ofs
-	get_tree().get_root().set_global_canvas_transform(m)
+	m.origin = ofs
+	get_node("/root").global_canvas_transform = m
 
 	screen_ofs = ofs
 	printt("**** screen ofs is ", screen_ofs)

--- a/device/globals/music_player.gd
+++ b/device/globals/music_player.gd
@@ -1,5 +1,3 @@
-var vm
-
 var last_volume = 1
 
 func _set(name, val):
@@ -21,7 +19,6 @@ func setup():
 	vm.connect("music_volume_changed", self, "global_volume_changed")
 	vm.connect("paused", self, "paused")
 	add_to_group("music")
-	var vm = get_node("/root/vm")
 	last_volume = get_volume()
 	if vm.settings != null:
 		set_volume(vm.settings.music_volume * get_volume())

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -5,7 +5,6 @@ extends Node2D
 var task
 var walk_destination
 var animation
-var vm
 var terrain
 var walk_path
 var walk_context
@@ -317,7 +316,6 @@ func _ready():
 		return
 
 	animation = get_node("animation")
-	vm = get_tree().get_root().get_node("vm")
 	vm.register_object("player", self)
 	#_update_terrain();
 	if has_node("animation"):

--- a/device/globals/sound.gd
+++ b/device/globals/sound.gd
@@ -1,5 +1,3 @@
-var vm
-
 var sounds = []
 var bg_path = ""
 var bg_volume = 1

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -1,5 +1,4 @@
 var global = null
-var vm
 var current_context
 
 func check_obj(name, cmd):

--- a/device/ui/main_menu.gd
+++ b/device/ui/main_menu.gd
@@ -102,7 +102,6 @@ func _ready():
 	get_node("exit").connect("pressed", self, "_on_exit_pressed")
 	#get_node("settings").connect("pressed", self, "settings_pressed")
 	#get_node("credits").connect("pressed",self,"credits_pressed")
-	vm = get_tree().get_root().get_node("vm")
 	set_process_input(true)
 	#main.set_current_scene(self)
 


### PR DESCRIPTION
I noticed that moving the camera from a corner to the center took a long time to start moving. After some digging around, it's because the camera would actually show they gray area outside the screen, which was properly fixed. Thus it started moving only after the camera though it was far enough from the bounds.

The solution is to check if the camera has been clamped down, and if so, reset its position. Without this fix it could take roughly a second for the camera to start moving, now it should take something like a delta-time between frames, like 30ms or whatever imperceptible.

This PR updates some pre-Godot3 code I found and renames (and comments on) some other stuff, so the functionality is hopefully clearer to someone who's never seen this before.