### PR TITLE
Exit node

### DIFF
--- a/device/globals/exit.gd
+++ b/device/globals/exit.gd
@@ -1,0 +1,44 @@
+extends "res://globals/interactive.gd"
+
+export(String, FILE, ".esc") var esc_script  # must contain :dblclick
+export var global_id = ""
+export var tooltip = ""
+
+var event_table = {}
+
+func get_tooltip():
+	if TranslationServer.get_locale() == ProjectSettings.get_setting("escoria/application/tooltip_lang_default"):
+		return tooltip
+	else:
+		if tr(tooltip) == tooltip:
+			return global_id+".tooltip"
+		else:
+			return tooltip
+
+func mouse_enter():
+	vm.hover_begin(self)
+	var tt = get_tooltip()
+	var text = tr(tt)
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip", text)
+
+func mouse_clicked(event):
+	if !(event is InputEventMouseButton):
+		return
+
+	if event.doubleclick:
+		vm.run_event(event_table["dblclick"])
+
+func mouse_exit():
+	vm.hover_end()
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip", "")
+
+func _ready():
+	if esc_script != "":
+		event_table = vm.compile(esc_script)
+		if !("dblclick" in event_table):
+			vm.report_errors(esc_script, ["Missing :dblclick"])
+
+	self.connect("mouse_entered", self, "mouse_enter")
+	self.connect("gui_input", self, "mouse_clicked")
+	self.connect("mouse_exited", self, "mouse_exit")
+

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -424,7 +424,6 @@ func finished(context):
 func change_scene(params, context):
 	# It might be tempting to use `get_tree().change_scene(params[0])`,
 	# but this custom solution is safer around your scene structure
-	printt("change scene to ", params[0])
 	#var res = ResourceLoader.load(params[0])
 	check_cache()
 	main.clear_scene()
@@ -434,7 +433,12 @@ func change_scene(params, context):
 	res_cache.clear()
 	var scene = res.instance()
 	if scene:
-		main.set_scene(scene)
+		if params.size() == 1:
+			printt("change scene to ", params[0])
+			main.set_scene(scene)
+		else:
+			printt("change scene to ", params[0], " position ", params[1])
+			main.set_scene(scene, params[1])
 	else:
 		report_errors("", ["Failed loading scene "+params[0]+" for change_scene"])
 

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -22,15 +22,14 @@ func clear_scene():
 	current.free()
 	current = null
 
-func set_scene(p_scene):
+func set_scene(p_scene, p_start_pos_node):
 	if current != null:
 		clear_scene()
 
 	if !p_scene:
 		return
-	var root = get_tree().get_root()
-	root.add_child(p_scene)
-	set_current_scene(p_scene)
+	get_node("/root").add_child(p_scene)
+	set_current_scene(p_scene, p_start_pos_node)
 
 func get_current_scene():
 	return current
@@ -73,11 +72,15 @@ func menu_collapse():
 		i -= 1
 		menu_stack[i].menu_collapsed()
 
-func set_current_scene(p_scene, events_path=null):
+func set_current_scene(p_scene, start_pos_node=null, events_path=null):
 	#print_stack()
 	current = p_scene
 	var root = get_tree().get_root()
 	root.move_child(p_scene, 0)
+
+	if start_pos_node:
+		var start_pos = current.get_node(start_pos_node).position
+		vm.get_object("player").teleport_pos(start_pos.x, start_pos.y)
 
 	if events_path:
 		vm.load_file(events_path)

--- a/device/globals/scene_base.gd
+++ b/device/globals/scene_base.gd
@@ -3,5 +3,6 @@ extends Node
 export(String, FILE) var events_path = ""
 
 func _ready():
-	main.call_deferred("set_current_scene", self, events_path)
+	var start_pos_node = null
+	main.call_deferred("set_current_scene", self, start_pos_node, events_path)
 

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -142,11 +142,15 @@ func walk_block(params):
 	return _walk(params, true)
 
 func change_scene(params):
+	var start_pos_node
+
 	# looking for localized string format in scene. this should be somewhere else
 	var sep = params[0].find(":\"")
+	if params.size() == 2:
+		start_pos_node = params[1]
 	if sep >= 0:
 		var path = params[0].substr(sep + 2, params[0].length() - (sep + 2))
-		vm.call_deferred("change_scene", [path], current_context)
+		vm.call_deferred("change_scene", [path, start_pos_node], current_context)
 	else:
 		vm.call_deferred("change_scene", params, current_context)
 

--- a/doc/esc_reference.md
+++ b/doc/esc_reference.md
@@ -112,8 +112,9 @@ set_globals i/* false
 - wait seconds
   Blocks execution of the current script for a number of seconds specified by the "seconds" parameter.
 
-- change_scene path
-  Loads a new scene, specified by "path"
+- change_scene path position
+  Loads a new scene, specified by "path". Optional parameters:
+  - position is the name of a Position2D node where the player will be put.
 
 - teleport object1 object2
   Sets the position of object1 to the position of object2


### PR DESCRIPTION
Steals some ideas from #44 but uses `TextureButton` because nothing else will work at all.

I plea that this gets merged anyway, because it's not horribly broken, as I'm using it successfully in my proto. Thus it should serve as a solid base for when `Area2D -> CollisionPolygon2D` becomes reality.