### PR TITLE
Quit by windows X button 3-17-18, and the project name is now "Prototype-Escoria"

### DIFF
--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -703,7 +703,7 @@ func _ready():
 	save_data = load(ProjectSettings.get_setting("escoria/application/save_data")).new()
 	save_data.start()
 
-	get_tree().set_auto_accept_quit(false)
+	get_tree().set_auto_accept_quit(ProjectSettings.get('escoria/platform/force_quit'))
 	randomize()
 	add_user_signal("music_volume_changed")
 	add_user_signal("paused", ["p_paused"])

--- a/device/project.godot
+++ b/device/project.godot
@@ -10,7 +10,7 @@ config_version=3
 
 [application]
 
-config/name="Prototype_Escoria"
+config/name="Escoria Prototype"
 run/main_scene="res://globals/scene_main.tscn"
 
 [autoload]

--- a/device/project.godot
+++ b/device/project.godot
@@ -10,7 +10,7 @@ config_version=3
 
 [application]
 
-config/name="Prototype"
+config/name="Prototype_Escoria"
 run/main_scene="res://globals/scene_main.tscn"
 
 [autoload]
@@ -53,6 +53,7 @@ ui/tooltip_follows_mouse=false
 ui/right_mouse_button_action_menu=false
 ui/action_menu=""
 ui/inventory=""
+platform/force_quit=true
 
 [gdnative]
 


### PR DESCRIPTION
Broken down from my previous Pull request. This gives power to close Escoria by simply hitting the X button on a window.

I also renamed the project from 'prototype' to prototype Escoria, because I thought that sounded too generic. 

