### PR TITLE
Fix halt/crash discovered in Daïza fork

### DIFF
--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -69,10 +69,7 @@ func finish():
 		var anim = get_node("animation")
 		if anim.has_animation("hide"):
 			anim.play("hide")
-		else:
-			_queue_free()
-	else:
-		_queue_free()
+	_queue_free()
 
 func init(p_params, p_context, p_intro, p_outro):
 	character = vm.get_object(p_params[0])

--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -183,7 +183,7 @@ func anim_get_ph_paths(p_anim):
 
 func play_anim(p_anim, p_notify = null, p_reverse = false, p_flip = null):
 
-	if p_notify is null && (!has_node("animation") || !get_node("animation").has_animation(p_anim)):
+	if p_notify == null && (!has_node("animation") || !get_node("animation").has_animation(p_anim)):
 		print("skipping cut scene '", p_anim, "'")
 		vm.finished(p_notify)
 		#_debug_states()


### PR DESCRIPTION
This PR contains two fixes for halts in the Daïza fork, and presumably other games which uses the same features.

- `device/globals/dialog_instance.gd`: Fix for animated dialogue boxes making the game unresponsive after disappearing
- `device/globals/item.gd`: Daïza has animations for items to play pick-up-sounds, etc., which I think is why we haven't noticed this one. When `p_notify` is null, it's not an instance of anything, which makes this check fail.