### PR TITLE
Clamp action menu within viewport

### DIFF
--- a/device/demo/ui/action_menu.tscn
+++ b/device/demo/ui/action_menu.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource path="res://globals/action_menu.gd" type="Script" id=1]
 
-[node name="action_menu" type="Node2D"]
+[node name="action_menu" type="Container"]
 z_index = 4096
 
 script = ExtResource( 1 )

--- a/device/globals/action_menu.gd
+++ b/device/globals/action_menu.gd
@@ -1,4 +1,4 @@
-extends Node2D
+extends Container
 
 var target
 func action_pressed(action):
@@ -11,6 +11,26 @@ func action_pressed(action):
 
 func target_visibility_changed():
 	stop()
+
+func check_clamp(click_pos, camera):
+	var my_size = get_size()
+	var vp_size = get_viewport().size
+
+	var dist_from_right = vp_size.x - (click_pos.x + my_size.x)
+	var dist_from_left = click_pos.x - my_size.x
+	var dist_from_bottom = vp_size.y - (click_pos.y + my_size.y)
+	var dist_from_top = click_pos.y - my_size.y
+
+	if dist_from_right < 0:
+		click_pos.x += dist_from_right
+	if dist_from_left < 0:
+		click_pos.x -= dist_from_left
+	if dist_from_bottom < 0:
+		click_pos.y += dist_from_bottom
+	if dist_from_top < 0:
+		click_pos.y -= dist_from_top
+
+	return click_pos - get_size()
 
 func start(p_target):
 	if target != p_target:

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -180,10 +180,10 @@ func clicked(obj, pos, input_event = null):
 func spawn_action_menu(obj):
 	if action_menu == null:
 		return
+	var pos = get_viewport().get_mouse_position()
+	var am_pos = action_menu.check_clamp(pos, camera)
+	action_menu.set_position(am_pos)
 	action_menu.show()
-	var pos
-	pos = get_viewport().get_mouse_position()
-	action_menu.position = pos
 	action_menu.start(obj)
 	#obj.grab_focus()
 


### PR DESCRIPTION
This alters the action menu so it has to inherit from a Container class.

The reason behind it is that Node2D boundary calculation may or may not
be impossible, but Containers do it naturally.

It has also been said that you should always use Control nodes for UI,
so this feels like a more idiomatic approach.

Partially fixes #91 