### PR TITLE
Support integer globals, including integer comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 logs/
 *.import
 *.translation
+
+# Platform specific metadata files
+.DS_Store
+thumbs.db

--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -1,6 +1,6 @@
 
 var commands = {
-	"set_global": { "min_args": 2, "types": [TYPE_STRING, TYPE_BOOL] },
+	"set_global": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING] },
 	"set_globals": { "min_args": 2, "types": [TYPE_STRING, TYPE_BOOL] },
 	"debug": { "min_args": 1 },
 	"anim": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL, TYPE_BOOL, TYPE_BOOL] },

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -239,6 +239,21 @@ func wait(params, level):
 	level.waiting = true
 	return state_yield
 
+func is_equal_to(name, val):
+	var global = get_global(name)
+	if global and val and global == val:
+		return true
+
+func is_greater_than(name, val):
+	var global = get_global(name)
+	if global and val and int(global) > int(val):
+		return true
+
+func is_less_than(name, val):
+	var global = get_global(name)
+	if global and val and int(global) < int(val):
+		return true
+
 func test(cmd):
 	if "if_true" in cmd:
 		for flag in cmd.if_true:
@@ -255,6 +270,30 @@ func test(cmd):
 	if "if_not_inv" in cmd:
 		for flag in cmd.if_not_inv:
 			if inventory_has(flag):
+				return false
+	if "if_eq" in cmd:
+		for flag in cmd.if_eq:
+			if !is_equal_to(flag[0], flag[1]):
+				return false
+	if "if_ne" in cmd:
+		for flag in cmd.if_ne:
+			if is_equal_to(flag[0], flag[1]):
+				return false
+	if "if_gt" in cmd:
+		for flag in cmd.if_gt:
+			if !is_greater_than(flag[0], flag[1]):
+				return false
+	if "if_ge" in cmd:
+		for flag in cmd.if_ge:
+			if is_less_than(flag[0], flag[1]):
+				return false
+	if "if_lt" in cmd:
+		for flag in cmd.if_lt:
+			if !is_less_than(flag[0], flag[1]):
+				return false
+	if "if_le" in cmd:
+		for flag in cmd.if_le:
+			if is_greater_than(flag[0], flag[1]):
 				return false
 
 	return true
@@ -331,6 +370,16 @@ func set_global(name, val):
 	globals[name] = val
 	#printt("global changed at global_vm, emitting for ", name, val)
 	emit_signal("global_changed", name)
+
+func dec_global(name, diff):
+	var global = get_global(name)
+	global = int(global) if global else 0
+	set_global(name, str(global - diff))
+
+func inc_global(name, diff):
+	var global = get_global(name)
+	global = int(global) if global else 0
+	set_global(name, str(global + diff))
 
 func set_globals(pat, val):
 	for key in globals:
@@ -763,4 +812,3 @@ func _ready():
 	connect("global_changed", self, "check_achievement")
 
 	set_process(true)
-

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -31,6 +31,14 @@ func set_global(params):
 	vm.set_global(params[0], params[1])
 	return vm.state_return
 
+func dec_global(params):
+	vm.dec_global(params[0], params[1])
+	return vm.state_return
+
+func inc_global(params):
+	vm.inc_global(params[0], params[1])
+	return vm.state_return
+
 func debug(params):
 	for p in params:
 		printraw(p)
@@ -301,8 +309,3 @@ func resume(context):
 
 func set_vm(p_vm):
 	vm = p_vm
-
-func _init():
-	#print("*************** vm level init")
-	#vm = get_tree().get_singleton("vm")
-	pass

--- a/doc/esc_reference.md
+++ b/doc/esc_reference.md
@@ -19,7 +19,7 @@ General
 ```
 
 - Global flags
-  Global flags define the state of the game, and can have a value of true or false. All commands or groups can be conditioned to the value of a global flag.
+  Global flags define the state of the game, and can have a value of true, false or an integer. All commands or groups can be conditioned to the value of a global flag.
 
 - Conditions
   In order to run a command conditionally dependin on the value of a flag, use [] with a list of conditions. All conditions in the list must be true. The character "!" before a flag can be used to negate it.
@@ -34,6 +34,14 @@ say player "The door is open" [door_open]
 # runs the group only if door_open is false and i/key is true
 > [!door_open,i/key]
 	say player "The door is close, maybe I can try this key in my inventory"
+```
+
+  Additionally, there's a set of comparison operators for use with global integers: `eq`, `gt` and `lt`, all of which can be negated.
+  Example:
+
+```
+# runs the command only if the value of pieces_of_eight is greater than 5
+set_state inv_pieces_of_eight money_bag [gt pieces_of_eight 5]
 ```
 
 - Commands
@@ -89,7 +97,13 @@ Command list
   Takes 1 or more strings, prints them to the console.
 
 - `set_global name value`
-  Changes the value of the global flag "name" with the value. Value can be "true" or "false"
+  Changes the value of the global "name" with the value. Value can be "true", "false" or an integer.
+
+- `dec_global name value`
+  Subtracts the value from global with given "name". Value and global must both be integers.
+
+- `inc_global name value`
+  Adds the value to global with given "name". Value and global must both be integers.
 
 - `set_globals pattern value`
   Changes the value of multiple globals using a wildcard pattern. Example:


### PR DESCRIPTION
The goal of this PR is to properly support non-boolean globals so that it will eventually be possible to add counters (#66) and write more advanced comparisons in esc scripts.

This will require thorough testing, since there are many parts of the framework which rely on the return value from `vm.get_global()` being a global.

I have altered the autosave functionality to write the actual value of globals to the save script and also added comparisons using `eq [global] [value]` and `ne [global] [value]`. The latter does not perform any sanity checks yet, and should at the very least attempt to collect a quoted string containing comma(s).

I also haven't looked into regular save games yet, to make sure these changes don't cause any regressions.