### PR TITLE
Restore `var vm` in `player.gd`

### DIFF
--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -5,6 +5,7 @@ extends Node2D
 var task
 var walk_destination
 var animation
+var vm  # A tool script cannot refer to singletons in Godot
 var terrain
 var walk_path
 var walk_context
@@ -316,6 +317,7 @@ func _ready():
 		return
 
 	animation = get_node("animation")
+	vm = $"/root/vm"
 	vm.register_object("player", self)
 	#_update_terrain();
 	if has_node("animation"):


### PR DESCRIPTION
Fix this problem that suddenly revealed itself.

```
SCRIPT ERROR: GDScript::reload: Compile Error: Identifier not found: vm
   At: res://globals/player.gd:57.
ERROR: reload: Method/Function Failed, returning: ERR_COMPILATION_FAILED
   At: modules/gdscript/gdscript.cpp:598.
```

It appears to have been introduced in 7336e54bd30ca1b696085e2dc5fdb7e78e6c4d19
but I haven't encountered this bug, so there may be a secondary cause.