### PR TITLE
Dialog color for player.gd and item.gd (for NPCs)

### DIFF
--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -138,6 +138,9 @@ func init(p_params, p_context, p_intro, p_outro):
 		show()
 		set_process(true)
 
+	if character.dialog_color:
+		label["custom_colors/default_color"] = character.dialog_color
+
 	label.bbcode_enabled = true
 
 	var parsed_ok = label.parse_bbcode(text)

--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -10,6 +10,7 @@ export var use_combine = false
 export var inventory = false
 export var use_action_menu = true
 export(int, -1, 360) var interact_angle = -1
+export(Color) var dialog_color = null
 export var talk_animation = "talk"
 export var active = true setget set_active,get_active
 export var placeholders = {}

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -12,6 +12,7 @@ var path_ofs
 export var speed = 300
 export var v_speed_damp = 1.0
 export(Script) var animations
+export(Color) var dialog_color = null
 var last_dir = 0
 var last_scale
 var pose_scale = 1


### PR DESCRIPTION
When we have `npc.gd`, move the color to it.

This disregards themes, because there are no custom Labels or RichTextLabels for different characters, and even if it was possible to create them, this is much less hassle.
