### PR TITLE
Stop player from walking when opening action menu

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -187,6 +187,10 @@ func clicked(obj, pos, input_event = null):
 func spawn_action_menu(obj):
 	if action_menu == null:
 		return
+
+	if player:
+		player.walk_stop(player.position)
+
 	var pos = get_viewport().get_mouse_position()
 	var am_pos = action_menu.check_clamp(pos, camera)
 	action_menu.set_position(am_pos)


### PR DESCRIPTION
Investigating if #98 is still relevant (it is not, it should be closed), I noticed the player can walk while the action menu is opened.

This is problematic if the walking causes the background to scroll, and the fix is trivial.

Please merge!