### PR TITLE
Fix tooltip mouse position by centering it

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -33,6 +33,7 @@ func mouse_enter(obj):
 	# When following the mouse, prevent text from flashing for a moment in the wrong place
 	if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
 		var pos = get_viewport().get_mouse_position()
+		pos -= tooltip.get_size() / Vector2(2, 1)
 		tooltip.set_position(pos)
 
 	# We must hide all non-inventory tooltips and interactions when the inventory is open


### PR DESCRIPTION
This should have been in fcca54c7c0a404d0d7e1f765c5270e3b51e9b569
but the test case happened to line the tooltip properly, when
another later test case showed that it does have to be set by center.