### PR TITLE
Hotspot and exit nodes

### DIFF
--- a/device/demo/actors/player/player.tscn
+++ b/device/demo/actors/player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://globals/player.gd" type="Script" id=1]
 [ext_resource path="res://demo/actors/player/player_anims.gd" type="Script" id=2]
@@ -131,8 +131,17 @@ tracks/0/keys = {
 "values": [ 5 ]
 }
 
-[node name="player" type="Node2D"]
+[sub_resource type="RectangleShape2D" id=8]
 
+custom_solver_bias = 0.0
+extents = Vector2( 10, 10 )
+
+[node name="player" type="KinematicBody2D"]
+
+input_pickable = false
+collision_layer = 1
+collision_mask = 1
+collision/safe_margin = 0.08
 script = ExtResource( 1 )
 speed = 300
 v_speed_damp = 1.0
@@ -163,5 +172,9 @@ anims/walk_down = SubResource( 5 )
 anims/walk_right = SubResource( 6 )
 anims/walk_up = SubResource( 7 )
 blend_times = [  ]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." index="2"]
+
+shape = SubResource( 8 )
 
 

--- a/device/demo/rooms/test/exit1.esc
+++ b/device/demo/rooms/test/exit1.esc
@@ -1,0 +1,2 @@
+:exit_scene
+say player exit_first_exit:"I'm at the first exit"

--- a/device/demo/rooms/test/exit2.esc
+++ b/device/demo/rooms/test/exit2.esc
@@ -1,0 +1,2 @@
+:exit_scene
+say player exit_second_exit:"I'm at the second exit"

--- a/device/demo/rooms/test/hotspot1.esc
+++ b/device/demo/rooms/test/hotspot1.esc
@@ -1,0 +1,5 @@
+:enter
+say player enter_first_trigger:"I entered the first trigger"
+
+:exit
+say player trigger_first_trigger:"I exited the first trigger"

--- a/device/demo/rooms/test/test.tscn
+++ b/device/demo/rooms/test/test.tscn
@@ -1,17 +1,19 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://globals/scene.gd" type="Script" id=1]
 [ext_resource path="res://demo/rooms/test/background.png" type="Texture" id=2]
-[ext_resource path="res://globals/background.gd" type="Script" id=3]
+[ext_resource path="res://globals/background_area.gd" type="Script" id=3]
 [ext_resource path="res://globals/terrain.gd" type="Script" id=4]
 [ext_resource path="res://demo/rooms/test/scales.png" type="Texture" id=5]
 [ext_resource path="res://demo/rooms/test/lightmap.png" type="Texture" id=6]
 [ext_resource path="res://demo/actors/player/player.tscn" type="PackedScene" id=7]
-[ext_resource path="res://demo/rooms/test/ice_cream.tscn" type="PackedScene" id=8]
-[ext_resource path="res://demo/rooms/test/box.tscn" type="PackedScene" id=9]
-[ext_resource path="res://demo/rooms/test/can.tscn" type="PackedScene" id=10]
-[ext_resource path="res://demo/rooms/test/chain_saw.tscn" type="PackedScene" id=11]
-[ext_resource path="res://globals/game.tscn" type="PackedScene" id=12]
+[ext_resource path="res://globals/exit.gd" type="Script" id=8]
+[ext_resource path="res://globals/trigger.gd" type="Script" id=9]
+[ext_resource path="res://demo/rooms/test/ice_cream.tscn" type="PackedScene" id=10]
+[ext_resource path="res://demo/rooms/test/box.tscn" type="PackedScene" id=11]
+[ext_resource path="res://demo/rooms/test/can.tscn" type="PackedScene" id=12]
+[ext_resource path="res://demo/rooms/test/chain_saw.tscn" type="PackedScene" id=13]
+[ext_resource path="res://globals/game.tscn" type="PackedScene" id=14]
 
 [sub_resource type="NavigationPolygon" id=1]
 
@@ -19,27 +21,35 @@ vertices = PoolVector2Array( 766.377, 567.042, 1204.89, 557.953, 1491.17, 617.02
 polygons = [ PoolIntArray( 0, 1, 2, 3, 4, 5 ), PoolIntArray( 6, 7, 0, 5, 8, 9 ) ]
 outlines = [ PoolVector2Array( 414.945, 555.219, 766.377, 567.042, 1204.89, 557.953, 1491.17, 617.027, 1491.17, 657.925, 1112.47, 689.271, 705.031, 687.462, 350.588, 673.829, 159.734, 646.564, 158.201, 587.028 ) ]
 
+[sub_resource type="Gradient" id=2]
+
+offsets = PoolRealArray( 0, 1 )
+colors = PoolColorArray( 0, 0, 0, 1, 1, 1, 1, 1 )
+
+[sub_resource type="GradientTexture" id=3]
+
+flags = 4
+gradient = SubResource( 2 )
+width = 2048
+
+[sub_resource type="ShaderMaterial" id=4]
+
+render_priority = 0
+
 [node name="scene" type="Node2D" index="0"]
 
 script = ExtResource( 1 )
+__meta__ = {
+"_edit_lock_": true
+}
+events_path = ""
 
-[node name="background" type="TextureRect" parent="." index="0"]
+[node name="background" type="Sprite" parent="." index="0"]
 
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = -2.0
-margin_right = 1498.0
-margin_bottom = 720.0
-rect_pivot_offset = Vector2( 0, 0 )
-mouse_filter = 1
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 2
-size_flags_vertical = 2
 texture = ExtResource( 2 )
-stretch_mode = 0
+centered = false
 script = ExtResource( 3 )
+_sections_unfolded = [ "Offset" ]
 action = "walk"
 
 [node name="terrain" type="Navigation2D" parent="." index="1"]
@@ -54,6 +64,8 @@ debug_mode = 1
 lightmap_modulate = Color( 1, 1, 1, 1 )
 scale_min = 0.5
 scale_max = 1.0
+player_speed_multiplier = 1.0
+player_doubleclick_speed_multiplier = 1.5
 
 [node name="NavigationPolygonInstance" type="NavigationPolygonInstance" parent="terrain" index="0"]
 
@@ -66,8 +78,92 @@ enabled = true
 position = Vector2( 742.426, 415.054 )
 z_index = 415
 _sections_unfolded = [ "Transform" ]
+dialog_color = null
+placeholders = {
 
-[node name="ice_cream" parent="." index="3" instance=ExtResource( 8 )]
+}
+
+[node name="exit1" type="TextureRect" parent="." index="3"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 585.0
+margin_top = 395.0
+margin_right = 645.0
+margin_bottom = 435.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 1
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 1
+texture = SubResource( 3 )
+expand = true
+stretch_mode = 2
+script = ExtResource( 8 )
+_sections_unfolded = [ "Rect" ]
+animations = null
+speed = 300
+scale_on_map = false
+light_on_map = false
+events_path = "res://demo/rooms/test/exit1.esc"
+global_id = "first_exit"
+tooltip = "First exit"
+
+[node name="trigger1" type="Area2D" parent="." index="4"]
+
+input_pickable = true
+gravity_vec = Vector2( 0, 1 )
+gravity = 98.0
+linear_damp = 0.1
+angular_damp = 1.0
+audio_bus_override = false
+audio_bus_name = "Master"
+script = ExtResource( 9 )
+_sections_unfolded = [ "Rect" ]
+animations = null
+speed = 300
+scale_on_map = false
+light_on_map = false
+events_path = "res://demo/rooms/test/trigger1.esc"
+global_id = "first_trigger"
+tooltip = "First trigger"
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="trigger1" index="0"]
+
+position = Vector2( 858.008, 414.05 )
+scale = Vector2( 3.7345, 3.00525 )
+build_mode = 0
+polygon = PoolVector2Array( -11.2083, -10.6006, 9.81654, -9.69969, 9.33321, 9.82031, -9.27502, 9.52 )
+
+[node name="exit2" type="Area2D" parent="." index="5"]
+
+input_pickable = true
+gravity_vec = Vector2( 0, 1 )
+gravity = 98.0
+linear_damp = 0.1
+angular_damp = 1.0
+audio_bus_override = false
+audio_bus_name = "Master"
+script = ExtResource( 8 )
+animations = null
+speed = 300
+scale_on_map = false
+light_on_map = false
+events_path = "res://demo/rooms/test/exit2.esc"
+global_id = "second_exit"
+tooltip = "Second exit"
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="exit2" index="0"]
+
+material = SubResource( 4 )
+build_mode = 0
+polygon = PoolVector2Array( 372.508, 392.173, 296.246, 442.437, 373.375, 476.235, 426.239, 420.771, 426.239, 360.108, 377.708, 386.973 )
+_sections_unfolded = [ "Material" ]
+
+[node name="ice_cream" parent="." index="6" instance=ExtResource( 10 )]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -78,24 +174,33 @@ margin_top = 343.0
 margin_right = 313.0
 margin_bottom = 461.0
 rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 mouse_filter = 1
 mouse_default_cursor_shape = 0
+tooltip = ""
+events_path = ""
+global_id = ""
+dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="ice_cream" index="0"]
 
 position = Vector2( 115.876, 115.875 )
 
-[node name="box" parent="." index="4" instance=ExtResource( 9 )]
+[node name="box" parent="." index="7" instance=ExtResource( 11 )]
 
 position = Vector2( 945.535, 381.07 )
+tooltip = ""
+events_path = ""
+global_id = ""
+dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="box" index="3"]
 
 position = Vector2( -53.8209, 46.6584 )
 
-[node name="can" parent="." index="5" instance=ExtResource( 10 )]
+[node name="can" parent="." index="8" instance=ExtResource( 12 )]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -106,16 +211,21 @@ margin_top = 364.0
 margin_right = 481.0
 margin_bottom = 404.0
 rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 mouse_filter = 1
 mouse_default_cursor_shape = 0
+tooltip = ""
 action = ""
+events_path = ""
+global_id = ""
+dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="can" index="0"]
 
 position = Vector2( 57.6177, 60.9417 )
 
-[node name="chainsaw" parent="." index="6" instance=ExtResource( 11 )]
+[node name="chainsaw" parent="." index="9" instance=ExtResource( 13 )]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -126,14 +236,19 @@ margin_top = 340.0
 margin_right = 1227.0
 margin_bottom = 435.0
 rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 mouse_filter = 1
 mouse_default_cursor_shape = 0
+tooltip = ""
+events_path = ""
+global_id = ""
+dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="chainsaw" index="0"]
 
 position = Vector2( 7.19824, 124.934 )
 
-[node name="game" parent="." index="7" instance=ExtResource( 12 )]
+[node name="game" parent="." index="10" instance=ExtResource( 14 )]
 
 

--- a/device/globals/background_area.gd
+++ b/device/globals/background_area.gd
@@ -6,7 +6,8 @@ var area
 func input(viewport, event, shape_idx):
 	if event is InputEventMouseButton and event.pressed:
 		if (event.button_index == BUTTON_LEFT):
-			get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "clicked", self, get_position() + event.position, event)
+			var pos = get_global_mouse_position()
+			get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "clicked", self, pos, event)
 		elif (event.button_index == BUTTON_RIGHT):
 			emit_right_click()
 

--- a/device/globals/exit.gd
+++ b/device/globals/exit.gd
@@ -1,0 +1,22 @@
+extends "res://globals/trigger.gd"
+
+func stopped_at(pos):
+	# TextureRect exits run this code
+	if self is Control and get_global_rect().has_point(pos):
+		run_event("exit_scene")
+
+func body_entered(body):
+	# Entering an exit node runs the `:exit_scene` event
+	if body is preload("res://globals/player.gd"):
+		run_event("exit_scene")
+
+func body_exited(body):
+	# Do nothing when exiting an exit node. Usually this code should not be hit.
+	return
+
+func _ready():
+	add_to_group("exit")
+
+	if not "exit_scene" in event_table:
+		vm.report_errors("exit", [":exit_scene missing for " + self.name])
+

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -1,6 +1,6 @@
 tool
 
-extends Node2D
+extends KinematicBody2D
 
 var task
 var walk_destination
@@ -159,6 +159,9 @@ func interact(p_params):
 		get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "interact", p_params)
 
 func walk_stop(pos):
+	# Notify exits of stop position
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "exit", "stopped_at", pos)
+
 	set_position(pos)
 	walk_path = []
 	task = null

--- a/device/globals/trigger.gd
+++ b/device/globals/trigger.gd
@@ -1,0 +1,85 @@
+extends "res://globals/interactive.gd"
+
+export(String, FILE, ".esc") var events_path
+export var global_id = ""
+export var tooltip = ""
+
+var event_table = {}
+
+func get_tooltip():
+	if TranslationServer.get_locale() == ProjectSettings.get_setting("escoria/platform/development_lang"):
+		if not global_id and ProjectSettings.get_setting("escoria/platform/force_tooltip_global_id"):
+			vm.report_errors("exit", ["Missing global_id in exit with tooltip '" + tooltip + "'"])
+		return tooltip
+
+	var tooltip_identifier = global_id + ".tooltip"
+	var translated = tr(tooltip_identifier)
+
+	if translated == tooltip_identifier:
+		if not global_id and ProjectSettings.get_setting("escoria/platform/force_tooltip_global_id"):
+			vm.report_errors("exit", ["Missing global_id in exit with tooltip '" + tooltip + "'"])
+		return tooltip_identifier
+
+	return translated
+
+func mouse_enter():
+	vm.hover_begin(self)
+	var tt = get_tooltip()
+	var text = tr(tt)
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip", text)
+
+func mouse_exit():
+	vm.hover_end()
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip", "")
+
+func area_input(viewport, event, shape_idx):
+	input(event)
+
+func input(event):
+	if !(event is InputEventMouseButton and event.is_pressed()):
+		return
+
+	var player = vm.get_object("player")
+	# Get mouse position, since event.position only works with Area2D exits
+	var pos = get_global_mouse_position()
+
+	if player and event.doubleclick:
+		player.set_position(pos)
+	elif player:
+		# Control blocks input to background, so make player walk
+		player.walk_to(pos)
+
+func body_entered(body):
+	if body is preload("res://globals/player.gd"):
+		run_event("enter")
+
+func body_exited(body):
+	if body is preload("res://globals/player.gd"):
+		run_event("exit")
+
+func run_event(event):
+	if event in event_table:
+		vm.run_event(event_table[event])
+
+func _ready():
+	var area
+	if has_node("area"):
+		area = get_node("area")
+	else:
+		area = self
+	if area is Area2D:
+		area.connect("input_event", self, "area_input")
+	else:
+		area.connect("gui_input", self, "input")
+
+	if events_path:
+		var f = File.new()
+		if f.file_exists(events_path):
+			event_table = vm.compile(events_path)
+
+	area.connect("mouse_entered", self, "mouse_enter")
+	area.connect("mouse_exited", self, "mouse_exit")
+
+	connect("body_entered", self, "body_entered")
+	connect("body_exited", self, "body_exited")
+

--- a/doc/triggers-and-exits.md
+++ b/doc/triggers-and-exits.md
@@ -1,0 +1,59 @@
+# Triggers and exits
+
+Triggers in Escoria are thought of as "things a character can walk on", either
+like opening a door in Prince of Persia by stepping on a plate or a more abstract
+"To street" exit trigger.
+
+Inert items, things that are "triggers or hotspots for the mouse" but not to be walked on, should
+be implemented using `item.gd`.
+
+Although triggers and exits can be attached to any type of `Node`,
+not every case works properly.
+
+The working cases are described here.
+
+Exit is extended from trigger. To make gameplay quicker and "more modern", trigger
+implements double-clicking, which therefore works in exit as well.
+
+## Concerning the player
+
+Your player character must be a `KinematicBody2D` in order to work with triggers
+and exits.
+
+If you refer to an old documentation that claims otherwise, and don't make it a
+`KinematicBody2D`, Godot will complain. So before you start, remember this.
+
+Also bear in mind that your player will need a `CollisionShape2D` or such to
+collide with the triggers and exits.
+
+## Triggers
+
+Triggers are `Area2D`, with the required `CollisionPolygon2D` child and optionally also
+a `Sprite`) child. You may name them freely.
+
+The `trigger.gd` script must be attached to the `Area2D`.
+
+The triggers react only on the player character, and the player character's position being
+within the Area2D.
+
+Note that you will have to create an ESC script with `:enter` and `:exit`
+which are triggered when the player enters or exits the `Area2D`.
+
+## Exits
+
+Exits can have the same node structure as a trigger or be `TextureRect`s. Be warned that
+`TextureRect` support may be dropped in the near future.
+
+The `exit.gd` script must be attached to either the `Area2D` or `TextureRect`.
+
+Because exits are meant for changing scenes, the event keyword is `:exit_scene` to avoid
+confusion with triggers.
+
+An example of this would be
+
+```
+:exit_scene
+set_global last_exit bridge
+change_scene res://game/rooms/office/main.tscn
+```
+


### PR DESCRIPTION
Based on the splendid work by @fleskesvor on #124 and it's predecessor, I cooked this up.

I believe it ticks every box

  * [X] Areas that react when the player walks on them
  * [X] Exit to another room (Also `TextureRect` support)
  * [X] Double-click for quick move to enable a modern feel
  * [X] Showcase the scenarios in the test room
  * [X] `exit.gd` is so simple that it's a good foundation if anyone comes up with a new use case
  * [X] Documentation

It also enforces the player character to be a  `KinematicBody2D`, which was discussed on IRC to be an acceptable change, because certain external documentation is for 2.1 anyway.

Thoughts?

PS.
In the spirit of full disclosure, my https://github.com/mjtorn/escoria/tree/devel does not really work with this, but this may be due to overlapping `Control` (in this case `TextureRect`) nodes and these should be deprecated as soon as #121 is closed. When it is closed, I propose we deprecate support for non-`Area2D` hotspots and exits because only one _good_ way to do things is better than implicitly tons of ways.