### PR TITLE
Fix missing global_ids and tooltips in demo room

### DIFF
--- a/device/demo/rooms/test/test.tscn
+++ b/device/demo/rooms/test/test.tscn
@@ -49,7 +49,6 @@ events_path = ""
 texture = ExtResource( 2 )
 centered = false
 script = ExtResource( 3 )
-_sections_unfolded = [ "Offset" ]
 action = "walk"
 
 [node name="terrain" type="Navigation2D" parent="." index="1"]
@@ -177,10 +176,6 @@ rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 1
 mouse_default_cursor_shape = 0
-tooltip = ""
-events_path = ""
-global_id = ""
-dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="ice_cream" index="0"]
@@ -190,10 +185,6 @@ position = Vector2( 115.876, 115.875 )
 [node name="box" parent="." index="7" instance=ExtResource( 11 )]
 
 position = Vector2( 945.535, 381.07 )
-tooltip = ""
-events_path = ""
-global_id = ""
-dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="box" index="3"]
@@ -214,11 +205,7 @@ rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 1
 mouse_default_cursor_shape = 0
-tooltip = ""
 action = ""
-events_path = ""
-global_id = ""
-dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="can" index="0"]
@@ -239,10 +226,6 @@ rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 1
 mouse_default_cursor_shape = 0
-tooltip = ""
-events_path = ""
-global_id = ""
-dialog_color = null
 use_custom_z = false
 
 [node name="interact_pos" type="Position2D" parent="chainsaw" index="0"]


### PR DESCRIPTION
Restores the global_ids, events_paths and tooltips that went missing in f6cb22049ac0d32a69ffdcb996a6cd4a541b2ba1.