### PR TITLE
Hide tooltip debug if there is no tooltip

### DIFF
--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -3,7 +3,8 @@ extends Control
 var background = null
 
 func set_tooltip(text):
-	printt("hud got tooltip text ", text)
+	if text:
+		printt("hud got tooltip text ", text)
 	get_node("tooltip").set_text(text)
 
 func inv_toggle():


### PR DESCRIPTION
I got annoyed by the amount of noise when trying to work on Spine animations, which requires a fair amount of temporary `printt()` debugging.

This is one of the main causes of useless prints, so I suggest we make it more relevant by not printing something that can be clearly seen in the game.