### PR TITLE
Fix confirm popup to close on animation_finished

### DIFF
--- a/device/demo/ui/confirm_popup.tscn
+++ b/device/demo/ui/confirm_popup.tscn
@@ -5,18 +5,18 @@
 [sub_resource type="Animation" id=1]
 
 resource_name = "close"
-length = 1.0
+length = 0.1
 loop = false
 step = 0.1
 
 [sub_resource type="Animation" id=2]
 
 resource_name = "open"
-length = 1.0
+length = 0.1
 loop = false
 step = 0.1
 
-[node name="confirm_popup" type="Control"]
+[node name="confirm_popup" type="Control" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -27,11 +27,12 @@ margin_bottom = 1079.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 0
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 script = ExtResource( 1 )
 
-[node name="Panel" type="TextureButton" parent="."]
+[node name="Panel" type="TextureButton" parent="." index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -44,7 +45,9 @@ margin_bottom = 759.0
 rect_scale = Vector2( 0.8, 0.8 )
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
+focus_mode = 2
 mouse_filter = 0
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 toggle_mode = false
@@ -52,7 +55,7 @@ enabled_focus_mode = 2
 shortcut = null
 group = null
 
-[node name="message" type="Label" parent="."]
+[node name="message" type="Label" parent="." index="1"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -66,6 +69,7 @@ rect_scale = Vector2( 1.3, 1.3 )
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 2
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 0
 custom_colors/font_color = Color( 0.807843, 0.156863, 0.219608, 1 )
@@ -79,7 +83,7 @@ percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="yes" type="TextureButton" parent="."]
+[node name="yes" type="TextureButton" parent="." index="2"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -92,7 +96,9 @@ margin_bottom = 644.0
 rect_scale = Vector2( 0.8, 0.8 )
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
+focus_mode = 2
 mouse_filter = 0
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 toggle_mode = false
@@ -100,7 +106,7 @@ enabled_focus_mode = 2
 shortcut = null
 group = null
 
-[node name="UI_YES" type="Label" parent="yes"]
+[node name="UI_YES" type="Label" parent="yes" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -114,6 +120,7 @@ rect_scale = Vector2( 2.5, 2.5 )
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 2
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 0
 custom_colors/font_color = Color( 0.988235, 0.913725, 0.309804, 1 )
@@ -125,7 +132,7 @@ percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="no" type="TextureButton" parent="."]
+[node name="no" type="TextureButton" parent="." index="3"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -138,7 +145,9 @@ margin_bottom = 643.0
 rect_scale = Vector2( 0.8, 0.8 )
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
+focus_mode = 2
 mouse_filter = 0
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 toggle_mode = false
@@ -146,7 +155,7 @@ enabled_focus_mode = 2
 shortcut = null
 group = null
 
-[node name="UI_NO" type="Label" parent="no"]
+[node name="UI_NO" type="Label" parent="no" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -160,6 +169,7 @@ rect_scale = Vector2( 2.5, 2.5 )
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 2
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 0
 custom_colors/font_color = Color( 0.988235, 0.913725, 0.309804, 1 )
@@ -171,16 +181,15 @@ percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="animation" type="AnimationPlayer" parent="."]
+[node name="animation" type="AnimationPlayer" parent="." index="4"]
 
+root_node = NodePath("..")
+autoplay = ""
 playback_process_mode = 1
 playback_default_blend_time = 0.0
-root_node = NodePath("..")
+playback_speed = 1.0
 anims/close = SubResource( 1 )
 anims/open = SubResource( 2 )
-playback/active = true
-playback/speed = 1.0
 blend_times = [  ]
-autoplay = ""
 
 

--- a/device/ui/confirm_popup.gd
+++ b/device/ui/confirm_popup.gd
@@ -34,9 +34,7 @@ func close():
 	anim.play("close")
 
 func anim_finished(anim_name):
-	# TODO use parameter here?
-	var cur = anim.get_current_animation()
-	if cur == "close":
+	if anim_name == "close":
 		queue_free()
 
 func input(event):


### PR DESCRIPTION
Fixes this issue mentioned in #142:

> While testing, I noticed that selecting "No" does not work, neither on "Quit" nor on "New Game" from an already running game. Moreover, the latter seems to leave the game in a very odd state when pressing "Yes" after first having pressed "No.
>
> As far as I can tell, this seems to always have been an issue in 3.0, while the tip of 2.1 works (with Godot 2.x), and it looks like it was an issue in 2.1 too. We might perform a bisect to check when the issue was introduced, but that will require a first pass with bisect to find the first commit which works with Godot v3.0.2 stable.