### PR TITLE
Make the "boot" script a ProjectSetting

### DIFF
--- a/device/project.godot
+++ b/device/project.godot
@@ -45,6 +45,7 @@ platform/dialog_option_height=1
 platform/dialog_type_suffix=""
 platform/dialog_force_centered=false
 platform/development_lang="en"
+platform/game_start_script="res://demo/game.esc"
 platform/force_text_ids=false
 platform/force_disable_typewriter_text=false
 platform/force_quit=true

--- a/device/ui/main_menu.gd
+++ b/device/ui/main_menu.gd
@@ -24,7 +24,7 @@ func newgame_pressed():
 func start_new_game(p_confirm):
 	if !p_confirm:
 		return
-	vm.load_file("res://demo/game.esc")
+	vm.load_file(ProjectSettings.get_setting("escoria/platform/game_start_script"))
 
 func continue_pressed():
 	button_clicked()


### PR DESCRIPTION
With this change, you don't need to commit a change into Escoria's
code to start your own game instead of the demo.