### PR TITLE
Do not look for inventory if it's not enabled

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -421,13 +421,14 @@ func load_hud():
 	get_node("hud_layer/hud").replace_by_instance(hres)
 
 	# Add inventory to hud layer, usually hud_minimal.tscn, if found in project settings
-	if !$hud_layer.has_node("inventory") and ProjectSettings.get_setting("escoria/ui/inventory"):
-		inventory = load(ProjectSettings.get_setting("escoria/ui/inventory")).instance()
-		if inventory and inventory is esc_type.INVENTORY:
-			inventory.hide()
-			$hud_layer.add_child(inventory)
-	else:
-		inventory = get_node("hud_layer/hud/inventory")
+	if inventory_enabled:
+		if !$hud_layer.has_node("inventory") and ProjectSettings.get_setting("escoria/ui/inventory"):
+			inventory = load(ProjectSettings.get_setting("escoria/ui/inventory")).instance()
+			if inventory and inventory is esc_type.INVENTORY:
+				inventory.hide()
+				$hud_layer.add_child(inventory)
+		else:
+			inventory = get_node("hud_layer/hud/inventory")
 
 	# Add action menu to hud layer if found in project settings
 	if ProjectSettings.get_setting("escoria/ui/action_menu"):


### PR DESCRIPTION
I bumped into this while setting up things for the jam game. I have a path for an inventory but it's not created yet, which obviously leads into problems. That's when I noticed there's an `export var` to disable the inventory altogether!

Feels like a super-useful feature in early development and why not respect it in real games as well.