### PR TITLE
Drop the hard requirement on arrow_prev/arrow_next

### DIFF
--- a/device/globals/inventory.gd
+++ b/device/globals/inventory.gd
@@ -141,10 +141,13 @@ func _ready():
 
 	page_size = get_node("slots").get_child_count()
 	sort_items()
-	get_node("arrow_prev").connect("pressed", self, "change_page", [-1])
-	#get_node("arrow_left").set_focus_mode(Control.FOCUS_NONE)
-	get_node("arrow_next").connect("pressed", self, "change_page", [1])
-	#get_node("arrow_right").set_focus_mode(Control.FOCUS_NONE)
+
+	if has_node("arrow_prev"):
+		$"arrow_prev".connect("pressed", self, "change_page", [-1])
+
+	if has_node("arrow_next"):
+		$"arrow_next".connect("pressed", self, "change_page", [1])
+
 	var items = get_node("items")
 	for i in range(0, items.get_child_count()):
 		var c = items.get_child(i)


### PR DESCRIPTION
It occurred to me that we're most likely doing a scumm/daiza inventory, with so few items we don't need arrows. Why make them and hide them when we can make them optional?