### PR TITLE
Work on clamping UI elements

### DIFF
--- a/device/globals/action_menu.gd
+++ b/device/globals/action_menu.gd
@@ -12,7 +12,7 @@ func action_pressed(action):
 func target_visibility_changed():
 	stop()
 
-func check_clamp(click_pos, camera):
+func check_clamp(click_pos):
 	var my_size = get_size()
 	var vp_size = get_viewport().size
 
@@ -30,7 +30,7 @@ func check_clamp(click_pos, camera):
 	if dist_from_top < 0:
 		click_pos.y -= dist_from_top
 
-	return click_pos - get_size() / 2
+	return click_pos - my_size / 2
 
 func start(p_target):
 	if target != p_target:

--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -69,6 +69,26 @@ func finish():
 			anim.play("hide")
 	_queue_free()
 
+func clamped_position(dialog_pos):
+	var my_size = $"anchor/text".get_size()
+	var center_offset = my_size.x / 2
+
+	var dist_from_right = vm.camera_limits.size.x - (dialog_pos.x + center_offset)
+	var dist_from_left = dialog_pos.x - center_offset
+	var dist_from_bottom = vm.camera_limits.size.y - (dialog_pos.y + my_size.y)
+	var dist_from_top = dialog_pos.y - my_size.y
+
+	if dist_from_right < 0:
+		dialog_pos.x += dist_from_right
+	if dist_from_left < 0:
+		dialog_pos.x -= dist_from_left
+	if dist_from_bottom < 0:
+		dialog_pos.y += dist_from_bottom
+	if dist_from_top < 0:
+		dialog_pos.y -= dist_from_top
+
+	return dialog_pos
+
 func init(p_params, p_context, p_intro, p_outro):
 	character = vm.get_object(p_params[0])
 	context = p_context
@@ -104,6 +124,8 @@ func init(p_params, p_context, p_intro, p_outro):
 			pos = character.get_node("dialog_pos").get_global_position()
 		else:
 			pos = character.get_position()
+
+		pos = clamped_position(pos)
 		set_position(pos)
 
 	if has_node("anchor/avatars"):

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -31,6 +31,31 @@ var tooltip
 func set_mode(p_mode):
 	mode = p_mode
 
+func tooltip_clamped_position(tt_pos):
+	var vp_size = get_viewport().size
+	var tt_size = tooltip.get_size()
+	tt_pos -= tt_size / Vector2(2, 1)
+
+	# var dist_from_right = vp_size.x - (tt_pos.x + tt_size.x)
+	# var dist_from_left = tt_pos.x - tt_size.x
+	var dist_from_bottom = vp_size.y - (tt_pos.y + tt_size.y)
+	var dist_from_top = tt_pos.y - tt_size.y
+
+	## XXX: Godot has serious issues with the width of the text, so tooltips need
+	## to be wide at a fixed size, which makes horizontal clamping impossible.
+	## The code is left here in case someone fixes Godot.
+	# if dist_from_right < 0:
+		# tt_pos.x += dist_from_right
+	# if dist_from_left < 0:
+		# tt_pos.x -= dist_from_left
+
+	if dist_from_bottom < 0:
+		tt_pos.y += dist_from_bottom
+	if dist_from_top < 0:
+		tt_pos.y -= dist_from_top
+
+	return tt_pos
+
 func mouse_enter(obj):
 	# Immediately bail out if the action menu is open
 	if action_menu and action_menu.is_visible():
@@ -41,9 +66,11 @@ func mouse_enter(obj):
 	var tt = obj.get_tooltip()
 
 	# When following the mouse, prevent text from flashing for a moment in the wrong place
-	if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
+	if tooltip and ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
 		var pos = get_viewport().get_mouse_position()
-		pos -= tooltip.get_size() / Vector2(2, 1)
+
+		pos = tooltip_clamped_position(pos)
+
 		tooltip.set_position(pos)
 
 	# We must hide all non-inventory tooltips and interactions when the inventory is open
@@ -382,7 +409,7 @@ func _input(ev):
 	if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
 		# Must verify `position` is there, key inputs do not have it
 		if vm.hover_object and "position" in ev:
-			var pos = ev.position - tooltip.get_size() / Vector2(2, 1)
+			var pos = tooltip_clamped_position(ev.position)
 			tooltip.set_position(pos)
 
 func set_inventory_enabled(p_enabled):

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -233,7 +233,7 @@ func spawn_action_menu(obj):
 		player.walk_stop(player.position)
 
 	var pos = get_viewport().get_mouse_position()
-	var am_pos = action_menu.check_clamp(pos, camera)
+	var am_pos = action_menu.check_clamp(pos)
 	action_menu.set_position(am_pos)
 	action_menu.show()
 	action_menu.start(obj)

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -3,13 +3,20 @@ extends Control
 var background = null
 
 func set_tooltip(text):
+	if !$"tooltip":
+		return
+
+	$"tooltip".text = text
+
 	if text:
 		printt("hud got tooltip text ", text)
-	$tooltip.set_text(text)
+		$"tooltip".show()
+	else:
+		$"tooltip".hide()
 
 func set_tooltip_visible(p_visible):
-	if $tooltip:
-		$tooltip.visible = p_visible
+	if $"tooltip":
+		$"tooltip".visible = p_visible
 
 func inv_toggle():
 	#get_node("inventory").toggle()
@@ -55,3 +62,4 @@ func _ready():
 	# Hide verb menu if hud layer has an action menu
 	if has_node("../action_menu"):
 		$verb_menu.hide()
+


### PR DESCRIPTION
Tooltips are hard due to how big they usually are, but clamping vertically is a good start and worth it.

Dialogs should never overflow. I think it's possible to mess with the camera so they still do, but in our jam game we see only great success.

Therefore this is one of those may-not-solve-world-hunger-but PRs. At least test it, please!