### PR TITLE
Make dialog_dialog behave like dialog_instance

### DIFF
--- a/device/globals/dialog_dialog.gd
+++ b/device/globals/dialog_dialog.gd
@@ -52,13 +52,15 @@ func start(params, p_context):
 			var tid = text.substr(0, sep)
 			text = text.substr(sep + 2, text.length() - (sep + 2))
 
-			var ptext = TranslationServer.translate(tid)
-			if ptext != tid:
-				text = ptext
-			elif force_ids:
-				text = tid + " (" + text + ")"
+			if TranslationServer.get_locale() != ProjectSettings.get_setting("escoria/platform/development_lang"):
+				var ptext = TranslationServer.translate(tid)
+				if ptext != tid:
+					text = ptext
+				elif force_ids:
+					text = "(NOT TRANSLATED)\n\n" + text
 
 		elif force_ids:
+			vm.report_errors("dialog_dialog", ["Missing text_id for string '" + text + "'"])
 			text = "(no id) " + text
 
 		label.set_text(text)


### PR DESCRIPTION
We were seeing the identifier bullshit in dialog choices.

I'm not sure if it's documented anywhere, or if it should go into #45, but even the `-` items in ESC-script dialog trees need identifiers or things will go south. In retrospect it makes sense, because you can have a lot of jokes (too many, even!) in having one choice and the player saying something else. Or just have an element of surprise when choosing a short option and have the player say something longer.
