### PR TITLE
ESC function to toggle HUD visibility

### DIFF
--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -7,6 +7,7 @@ var commands = {
 	"debug": { "min_args": 1 },
 	"anim": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL, TYPE_BOOL, TYPE_BOOL] },
 	"set_state": { "min_args": 2 },
+	"set_hud_visible": { "min_args": 1, "types": [TYPE_BOOL]},
 	"say": { "min_args": 2 },
 	"?": { "alias": "dialog"},
 	"cut_scene": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL, TYPE_BOOL, TYPE_BOOL] },

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -418,7 +418,7 @@ func set_camera_limits():
 
 func load_hud():
 	var hres = vm.res_cache.get_resource(vm.get_hud_scene())
-	get_node("hud_layer/hud").replace_by_instance(hres)
+	$"hud_layer/hud".replace_by_instance(hres)
 
 	# Add inventory to hud layer, usually hud_minimal.tscn, if found in project settings
 	if inventory_enabled:

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -191,6 +191,9 @@ func inventory_set(p_obj, p_has):
 func say(params, level):
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "dialog", "say", params, level)
 
+func set_hud_visible(p_visible):
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_visible", p_visible)
+
 func dialog_config(params):
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "dialog", "config", params)
 

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -41,6 +41,9 @@ func menu_opened():
 func menu_closed():
 	show()
 
+func set_visible(p_visible):
+	visible = p_visible
+
 func _ready():
 	add_to_group("hud")
 	add_to_group("game")

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -68,6 +68,9 @@ func set_state(params):
 	vm.set_state(params[0], params[1])
 	return vm.state_return
 
+func set_hud_visible(params):
+	vm.set_hud_visible(params[0])
+
 func say(params):
 	if !check_obj(params[0], "say"):
 		return vm.state_return

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -120,6 +120,9 @@ When used on a player object, the command is used to dress the player in a costu
 
 Items can also change state by playing animations from an `AnimationPlayer` named "animation". The `AnimationPlayer` is typically used to change the texture of a `Sprite` node, but it's also possible to add additional tracks for changing the tooltip and other properties of the item scene. By using keyframes and looping, any given state can also use multiple textures to bring more life to the item.
 
+- `set_hud_visible visible`
+  If you have a cut-scene-like sequence where the player doesn't have control, and you also have HUD elements visible, use this to hide the HUD. You want to do that because it explicitly signals the player that there is no control over the game at the moment. "visible" is true or false.
+
 - `say object text [type] [avatar]`
   Runs the specified string as a dialog said by the object. Blocks execution until the dialog finishes playing. Optional parameters:
   - "type" determines the type of dialog UI to use. Default value is "default"


### PR DESCRIPTION
If your inventory is overlaid onto the game, and you want to
do camera-movement trickery, it's hard to set the scene so
the inventory doesn't get in the way.

It's also confusing for the brain because having an interactive
element feels like the game would be interactive during the
camera movement.