### PR TITLE
Fix action_menu show/hide to toggle only the tooltip

### DIFF
--- a/device/globals/action_menu.gd
+++ b/device/globals/action_menu.gd
@@ -39,7 +39,7 @@ func start(p_target):
 
 		# Do not display the tooltip alongside the menu
 		if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
-			get_tree().call_group("hud", "hide")
+			get_tree().call_group("hud", "set_tooltip_visible", false)
 
 	var scale = ProjectSettings.get_setting("escoria/platform/action_menu_scale")
 	set_scale(Vector2(scale, scale))
@@ -50,7 +50,7 @@ func stop():
 	target = null
 	hide()
 	if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
-		get_tree().call_group("hud", "show")
+		get_tree().call_group("hud", "set_tooltip_visible", true)
 
 func _ready():
 

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -27,6 +27,11 @@ func set_mode(p_mode):
 	mode = p_mode
 
 func mouse_enter(obj):
+	# Immediately bail out if the action menu is open
+	if action_menu and action_menu.is_visible():
+		assert(!tooltip.visible)
+		return
+
 	var text
 	var tt = obj.get_tooltip()
 
@@ -70,6 +75,13 @@ func mouse_enter(obj):
 		vm.hover_begin(obj)
 
 func mouse_exit(obj):
+	# If we don't return here, and the cursor is moved around over
+	# items with the action menu open, we would get an empty tooltip
+	# when the action menu closes
+	if action_menu and action_menu.is_visible():
+		assert(!tooltip.visible)
+		return
+
 	var text
 	#var tt = obj.get_tooltip()
 	if current_action != "" && current_tool != null:

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -7,6 +7,10 @@ func set_tooltip(text):
 		printt("hud got tooltip text ", text)
 	get_node("tooltip").set_text(text)
 
+func set_tooltip_visible(p_visible):
+	if tooltip:
+		tooltip.visible = p_visible
+
 func inv_toggle():
 	#get_node("inventory").toggle()
 	pass


### PR DESCRIPTION
The code was hiding the entire HUD because of the action menu,
though the comment pointed out it's the tooltip that needs to
be hidden.

This implements the proper code for it.

It also takes into account the tooltip on item mouse enter/exit.