### PR TITLE
Allow textured content in confirmation popup

### DIFF
--- a/device/ui/confirm_popup.gd
+++ b/device/ui/confirm_popup.gd
@@ -5,7 +5,11 @@ var slot = ""
 var anim
 
 func start(message, p_target, p_slot):
-	get_node("message").set_text(message)
+	if has_node("message"):
+		$"message".set_text(message)
+	else:
+		# This allows having TextureRects by the name of eg UI_CONFIRM_NEW_GAME or UI_CONFIRM_QUIT
+		get_node(message).show()
 	target = p_target
 	slot = p_slot
 	anim.play("open")


### PR DESCRIPTION
Sometimes you want to use a `TextureRect` in your
confirmation popups, like if the artist wanted
to add decorations to the text.

This makes removing the `message` node possible
and replacing it with nodes named after the translation
identifiers.