### PR TITLE
Fix bg_music on change_scene

### DIFF
--- a/device/globals/bg_music.gd
+++ b/device/globals/bg_music.gd
@@ -38,4 +38,5 @@ func load_stream():
 	stream = get_node("stream")
 
 func _ready():
+	add_to_group("game")
 	call_deferred("load_stream")


### PR DESCRIPTION
It turns out my initial assumption was wrong: The problem wasn't due to race conditions where state would be set before `bg_music` was available, but because when `vm` is cleared of state in https://github.com/godotengine/escoria/blob/master/device/globals/global_vm.gd#L662, `bg_music`, unlike `telon` never registers with `vm` again, because it wasn't in the "game" group.

When `demo/game.esc` or `quick_save.esc` are triggered by starting a new game or loading an autosave, ~`change_scene` is run, which caused the `bg_music` object to be removed. The reason why it's been working with the `:scene` command in my testing is that I've been running single scenes with background music from the editor, in which case the scene transition which caused `bg_music` to be erased didn't happen.~ **EDIT** Actually, this is not the case. It's running `load_file()` in `global_vm` when `load` is in the run esc script that explicitly runs `clear()`. This is intended behaviour though, as `:load` is used when setting up a game to be able to start from a clear state. `game_cleared()` was also already defined in `bg_music` in spite of never being called, so this must have been intended behaviour and have likely worked at some point before the FOSS release. **/EDIT**

Looking at blame, `bg_music` never belonged to the "game" group, even in 2.1, so this seems to never have been working. Daïza has worked around this issue by setting the background music directly in `bg_music.tscn` (https://github.com/flossmanualsfr/escoria/blob/master/device/globals/bg_music.tscn#L4) and using autoplay to play the music.