### PR TITLE
Fix hud z index

### DIFF
--- a/device/demo/ui/dialog_default.tscn
+++ b/device/demo/ui/dialog_default.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://demo/ui/dialog_theme.tres" type="Theme" id=2]
 
 
-[node name="dialog_instance" type="Container"]
+[node name="dialog_instance" type="Node2D"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -24,7 +24,7 @@ typewriter_text = true
 characters_per_second = 45.0
 fixed_pos = false
 
-[node name="anchor" type="Container" parent="." index="0"]
+[node name="anchor" type="Node2D" parent="." index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0

--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -1,4 +1,4 @@
-extends Container
+extends Node2D
 
 var context
 var text

--- a/device/globals/dialog_player.gd
+++ b/device/globals/dialog_player.gd
@@ -10,6 +10,7 @@ func say(params, callback):
 		type = params[2]
 	type = type + ProjectSettings.get_setting("escoria/platform/dialog_type_suffix")
 	var inst = get_resource(type).instance()
+	var z = inst.get_z_index()
 	get_node("/root").get_child(0).add_child(inst)
 	var intro = true
 	var outro = true
@@ -17,6 +18,7 @@ func say(params, callback):
 		intro = types[type][0]
 		outro = types[type][1]
 	inst.init(params, callback, intro, outro)
+	inst.set_z_index(z)
 
 func config(params):
 	types[params[0]] = [params[1], params[2]]

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -441,7 +441,7 @@ func load_hud():
 	#else:
 	#	get_node("hud_layer/hud/inv_toggle").hide()
 
-	tooltip = get_node("hud_layer/hud/tooltip")
+	tooltip = get_node("hud_layer/hud/tt_layer/tooltip")
 
 func _ready():
 	add_to_group("game")

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -5,7 +5,7 @@ var background = null
 func set_tooltip(text):
 	if text:
 		printt("hud got tooltip text ", text)
-	get_node("tooltip").set_text(text)
+	get_node("tt_layer/tooltip").set_text(text)
 
 func inv_toggle():
 	#get_node("inventory").toggle()
@@ -48,3 +48,4 @@ func _ready():
 	# Hide verb menu if hud layer has an action menu
 	if has_node("../action_menu"):
 		$verb_menu.hide()
+

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -15,11 +15,16 @@ margin_bottom = 40.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 0
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
 script = ExtResource( 1 )
 
-[node name="tooltip" type="Label" parent="."]
+[node name="tt_layer" type="Node2D" parent="." index="0"]
+
+z_index = 2
+
+[node name="tooltip" type="Label" parent="tt_layer" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -32,6 +37,7 @@ margin_bottom = 115.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 2
+mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
@@ -41,18 +47,21 @@ percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
 
-[node name="inventory" parent="." instance=ExtResource( 2 )]
+[node name="inventory" parent="." index="1" instance=ExtResource( 2 )]
 
 margin_left = 702.0
 margin_top = 457.0
 margin_right = 742.0
 margin_bottom = 497.0
+rect_clip_content = false
+is_collapsible = false
 
-[node name="verb_menu" parent="." instance=ExtResource( 3 )]
+[node name="verb_menu" parent="." index="2" instance=ExtResource( 3 )]
 
 margin_left = 63.0
 margin_top = 519.0
 margin_right = 103.0
 margin_bottom = 559.0
+mouse_default_cursor_shape = 0
 
 

--- a/device/ui/hud_minimal.tscn
+++ b/device/ui/hud_minimal.tscn
@@ -17,7 +17,11 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 script = ExtResource( 1 )
 
-[node name="tooltip" type="Label" parent="."]
+[node name="tt_layer" type="Node2D" parent="." index="0"]
+
+z_index = 2
+
+[node name="tooltip" type="Label" parent="tt_layer" index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0


### PR DESCRIPTION
Our Jam Game had a lot of z-index issues in the HUD. Tooltips and dialog were positioned underneath the player and other objects.

The reverted commit should never have happened. It made sense at the time, because it wasn't apparent in any known demo or proto. The positioning is off regardless of the change, at least in our Jam Game, so reverting it has a negligible effect at best for positioning and makes the text appear on top, fixing a very relevant regression.

Tooltips were mostly correct for items, but broke down hard with the inventory, which uses `Node2D`. Having a layer node for it makes it possible to have the tooltips where you'd expect them: readable on top of the item.

I don't think there's much to discuss on this one, please kick it in.