### PR TITLE
HUD positioning

### DIFF
--- a/device/demo/ui/inventory.tscn
+++ b/device/demo/ui/inventory.tscn
@@ -1,22 +1,30 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
-[ext_resource path="res://globals/inventory.gd" type="Script" id=1]
-[ext_resource path="res://demo/ui/inventory_items.tscn" type="PackedScene" id=2]
+[ext_resource path="res://globals/white.png" type="Texture" id=1]
+[ext_resource path="res://globals/inventory.gd" type="Script" id=2]
+[ext_resource path="res://demo/ui/inventory_items.tscn" type="PackedScene" id=3]
 
-[node name="inventory" type="Control" index="0"]
+[node name="inventory" type="TextureRect" index="0"]
 
+self_modulate = Color( 0, 0, 0, 0.196078 )
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_right = 40.0
-margin_bottom = 40.0
+margin_right = 600.0
+margin_bottom = 280.0
 rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 mouse_filter = 0
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
-script = ExtResource( 1 )
+texture = ExtResource( 1 )
+expand = true
+stretch_mode = 0
+script = ExtResource( 2 )
+_sections_unfolded = [ "Visibility" ]
+is_collapsible = false
 
 [node name="slots" type="Control" parent="." index="0"]
 
@@ -27,6 +35,7 @@ anchor_bottom = 0.0
 margin_right = 40.0
 margin_bottom = 40.0
 rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 mouse_filter = 0
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
@@ -68,6 +77,7 @@ margin_top = 68.0
 margin_right = 506.0
 margin_bottom = 108.0
 rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 focus_mode = 2
 mouse_filter = 0
 mouse_default_cursor_shape = 0
@@ -90,6 +100,7 @@ margin_top = 167.0
 margin_right = 501.0
 margin_bottom = 207.0
 rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
 focus_mode = 2
 mouse_filter = 0
 mouse_default_cursor_shape = 0
@@ -100,7 +111,7 @@ enabled_focus_mode = 2
 shortcut = null
 group = null
 
-[node name="items" parent="." index="3" instance=ExtResource( 2 )]
+[node name="items" parent="." index="3" instance=ExtResource( 3 )]
 
 visible = false
 

--- a/device/globals/dialog_player.gd
+++ b/device/globals/dialog_player.gd
@@ -10,7 +10,7 @@ func say(params, callback):
 		type = params[2]
 	type = type + ProjectSettings.get_setting("escoria/platform/dialog_type_suffix")
 	var inst = get_resource(type).instance()
-	get_node("/root").get_child(0).add_child(inst)
+	get_parent().add_child(inst)
 	var intro = true
 	var outro = true
 	if type in types:

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -410,7 +410,7 @@ func _input(ev):
 		# Must verify `position` is there, key inputs do not have it
 		if vm.hover_object and "position" in ev:
 			var pos = tooltip_clamped_position(ev.position)
-			tooltip.set_position(pos)
+			tooltip.set_global_position(pos)
 
 func set_inventory_enabled(p_enabled):
 	inventory_enabled = p_enabled

--- a/device/globals/game.tscn
+++ b/device/globals/game.tscn
@@ -1,18 +1,15 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://globals/game.gd" type="Script" id=1]
-[ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=2]
 
-[node name="game" type="Node"]
+[node name="game" type="Node" index="0"]
 
 script = ExtResource( 1 )
 fallbacks_path = "res://demo/fallbacks.esc"
 inventory_enabled = true
 camera_limits = Rect2( 0, 0, 0, 0 )
 
-[node name="dialog_player" parent="." index="0" instance=ExtResource( 2 )]
-
-[node name="hud_layer" type="CanvasLayer" parent="." index="1"]
+[node name="hud_layer" type="CanvasLayer" parent="." index="0"]
 
 layer = 1
 offset = Vector2( 0, 0 )
@@ -22,16 +19,14 @@ transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
 [node name="hud" parent="hud_layer" index="0" instance_placeholder="res://ui/hud.tscn"]
 
-mouse_default_cursor_shape = 0
-
-[node name="wait_timer" type="Timer" parent="." index="2"]
+[node name="wait_timer" type="Timer" parent="." index="1"]
 
 process_mode = 1
 wait_time = 1.0
 one_shot = false
 autostart = false
 
-[node name="camera" type="Camera2D" parent="." index="3"]
+[node name="camera" type="Camera2D" parent="." index="2"]
 
 anchor_mode = 1
 rotating = false

--- a/device/globals/game_am.tscn
+++ b/device/globals/game_am.tscn
@@ -1,34 +1,34 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://globals/game.gd" type="Script" id=1]
-[ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=2]
 
-[node name="game" type="Node"]
+[node name="game" type="Node" index="0"]
 
 script = ExtResource( 1 )
 fallbacks_path = "res://demo/fallbacks.esc"
 inventory_enabled = true
 camera_limits = Rect2( 0, 0, 0, 0 )
 
-[node name="dialog_player" parent="." index="0" instance=ExtResource( 2 )]
-
-[node name="hud_layer" type="CanvasLayer" parent="." index="1"]
+[node name="hud_layer" type="CanvasLayer" parent="." index="0"]
 
 layer = 1
 offset = Vector2( 0, 0 )
 rotation = 0.0
 scale = Vector2( 1, 1 )
+transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
 [node name="hud" parent="hud_layer" index="0" instance_placeholder="res://ui/hud_minimal.tscn"]
 
-[node name="wait_timer" type="Timer" parent="." index="2"]
+mouse_default_cursor_shape = 0
+
+[node name="wait_timer" type="Timer" parent="." index="1"]
 
 process_mode = 1
 wait_time = 1.0
 one_shot = false
 autostart = false
 
-[node name="camera" type="Camera2D" parent="." index="3"]
+[node name="camera" type="Camera2D" parent="." index="2"]
 
 anchor_mode = 1
 rotating = false
@@ -43,6 +43,8 @@ drag_margin_h_enabled = true
 drag_margin_v_enabled = true
 smoothing_enabled = false
 smoothing_speed = 5.0
+offset_v = 0.0
+offset_h = 0.0
 drag_margin_left = 0.2
 drag_margin_top = 0.2
 drag_margin_right = 0.2

--- a/device/globals/main.tscn
+++ b/device/globals/main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://globals/main.gd" type="Script" id=1]
 [ext_resource path="res://globals/bg_music.tscn" type="PackedScene" id=2]
-[ext_resource path="res://ui/dd_player.tscn" type="PackedScene" id=3]
+[ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=3]
+[ext_resource path="res://ui/dd_player.tscn" type="PackedScene" id=4]
 
-[node name="main" type="Node" index="0"]
+[node name="main" type="Node"]
 
 pause_mode = 2
 script = ExtResource( 1 )
@@ -22,6 +23,8 @@ transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 [node name="bg_music" parent="layers/telon" index="0" instance=ExtResource( 2 )]
 
 rect_clip_content = false
+interact_position = null
+dialog_color = null
 
 [node name="telon" parent="layers/telon" index="1" instance_placeholder="res://globals/telon.tscn"]
 
@@ -35,7 +38,9 @@ rotation = 0.0
 scale = Vector2( 1, 1 )
 transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
-[node name="dd_player" parent="layers/dialog" index="0" instance=ExtResource( 3 )]
+[node name="dialog_player" parent="layers/dialog" index="0" instance=ExtResource( 3 )]
+
+[node name="dd_player" parent="layers/dialog" index="1" instance=ExtResource( 4 )]
 
 [node name="menu" type="CanvasLayer" parent="layers" index="2"]
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -7,14 +7,12 @@
 [node name="hud" type="Control" index="0"]
 
 anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_right = 40.0
-margin_bottom = 40.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
-mouse_filter = 0
+mouse_filter = 2
 mouse_default_cursor_shape = 0
 size_flags_horizontal = 2
 size_flags_vertical = 2
@@ -55,10 +53,12 @@ is_collapsible = false
 
 [node name="verb_menu" parent="." index="2" instance=ExtResource( 3 )]
 
-margin_left = 63.0
-margin_top = 519.0
-margin_right = 103.0
-margin_bottom = 559.0
+anchor_top = 1.0
+anchor_bottom = 1.0
+margin_left = 20.0
+margin_top = -260.0
+margin_right = 0.0
+margin_bottom = 0.0
 mouse_default_cursor_shape = 0
 
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -19,31 +19,7 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 script = ExtResource( 1 )
 
-[node name="tooltip" type="Label" parent="." index="0"]
-
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 160.0
-margin_top = 58.0
-margin_right = 1149.0
-margin_bottom = 115.0
-rect_pivot_offset = Vector2( 0, 0 )
-rect_clip_content = false
-mouse_filter = 2
-mouse_default_cursor_shape = 0
-size_flags_horizontal = 2
-size_flags_vertical = 0
-custom_colors/font_color = Color( 0, 0, 0, 1 )
-align = 1
-valign = 1
-percent_visible = 1.0
-lines_skipped = 0
-max_lines_visible = -1
-_sections_unfolded = [ "Visibility" ]
-
-[node name="inventory" parent="." index="1" instance=ExtResource( 2 )]
+[node name="inventory" parent="." index="0" instance=ExtResource( 2 )]
 
 modulate = Color( 1, 1, 1, 1 )
 self_modulate = Color( 0, 0, 0, 0.196078 )
@@ -56,9 +32,8 @@ margin_top = -400.0
 margin_right = -20.0
 margin_bottom = -100.0
 texture = ExtResource( 3 )
-_sections_unfolded = [ "Anchor", "Margin", "Rect", "Visibility" ]
 
-[node name="verb_menu" parent="." index="2" instance=ExtResource( 4 )]
+[node name="verb_menu" parent="." index="1" instance=ExtResource( 4 )]
 
 anchor_top = 1.0
 anchor_bottom = 1.0
@@ -67,5 +42,28 @@ margin_top = -260.0
 margin_right = 0.0
 margin_bottom = 0.0
 mouse_default_cursor_shape = 0
+
+[node name="tooltip" type="Label" parent="." index="2"]
+
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 160.0
+margin_top = -842.0
+margin_right = 1149.0
+margin_bottom = -785.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 2
+size_flags_vertical = 0
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+align = 1
+valign = 1
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
 
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://globals/hud.gd" type="Script" id=1]
 [ext_resource path="res://demo/ui/inventory.tscn" type="PackedScene" id=2]
-[ext_resource path="res://demo/ui/verb_menu.tscn" type="PackedScene" id=3]
+[ext_resource path="res://globals/white.png" type="Texture" id=3]
+[ext_resource path="res://demo/ui/verb_menu.tscn" type="PackedScene" id=4]
 
 [node name="hud" type="Control" index="0"]
 
@@ -44,14 +45,20 @@ _sections_unfolded = [ "Visibility" ]
 
 [node name="inventory" parent="." index="1" instance=ExtResource( 2 )]
 
-margin_left = 702.0
-margin_top = 457.0
-margin_right = 742.0
-margin_bottom = 497.0
-rect_clip_content = false
-is_collapsible = false
+modulate = Color( 1, 1, 1, 1 )
+self_modulate = Color( 0, 0, 0, 0.196078 )
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -620.0
+margin_top = -400.0
+margin_right = -20.0
+margin_bottom = -100.0
+texture = ExtResource( 3 )
+_sections_unfolded = [ "Anchor", "Margin", "Rect", "Visibility" ]
 
-[node name="verb_menu" parent="." index="2" instance=ExtResource( 3 )]
+[node name="verb_menu" parent="." index="2" instance=ExtResource( 4 )]
 
 anchor_top = 1.0
 anchor_bottom = 1.0


### PR DESCRIPTION
Anchor verb menu and inventory to the bottom left and right, respectively, to make the HUD less dependent on screen sizes.

The inventory takes up too much screen space in room2 and needs adjusting.