### PR TITLE
Fix teleporting an item to use Godot 3.0 API

### DIFF
--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -262,7 +262,7 @@ func set_state(p_state, p_force = false):
 			animation.play(p_state)
 
 func teleport(obj):
-	set_position(obj.get_global_pos())
+	set_position(obj.global_position)
 	_update_terrain()
 
 func teleport_pos(x, y):


### PR DESCRIPTION
This is a critical yet trivial fix.