### PR TITLE
Toggle trigger/exit activity with `visible`

### DIFF
--- a/device/demo/rooms/test/test.tscn
+++ b/device/demo/rooms/test/test.tscn
@@ -111,7 +111,6 @@ light_on_map = false
 events_path = "res://demo/rooms/test/exit1.esc"
 global_id = "first_exit"
 tooltip = "First exit"
-active = true
 
 [node name="trigger1" type="Area2D" parent="." index="4"]
 
@@ -131,7 +130,6 @@ light_on_map = false
 events_path = "res://demo/rooms/test/hotspot1.esc"
 global_id = "first_trigger"
 tooltip = "First trigger"
-active = true
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="trigger1" index="0"]
 
@@ -157,7 +155,6 @@ light_on_map = false
 events_path = "res://demo/rooms/test/exit2.esc"
 global_id = "second_exit"
 tooltip = "Second exit"
-active = true
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="exit2" index="0"]
 

--- a/device/globals/exit.gd
+++ b/device/globals/exit.gd
@@ -3,12 +3,14 @@ extends "res://globals/trigger.gd"
 func stopped_at(pos):
 	# TextureRect exits run this code
 	if self is Control and get_global_rect().has_point(pos):
-		run_event("exit_scene")
+		if self.visible:
+			run_event("exit_scene")
 
 func body_entered(body):
 	# Entering an exit node runs the `:exit_scene` event
 	if body is esc_type.PLAYER:
-		run_event("exit_scene")
+		if self.visible:
+			run_event("exit_scene")
 
 func body_exited(body):
 	# Do nothing when exiting an exit node. Usually this code should not be hit.

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -367,13 +367,18 @@ func get_object(name):
 
 func register_object(name, val):
 	objects[name] = val
-	if name in states:
-		val.set_state(states[name])
-	else:
-		val.set_state("default")
-	if name in actives:
-		val.set_active(actives[name])
 	val.connect("tree_exited", self, "object_exit_scene", [name])
+
+	# Most objects have states/animations, but don't count on it
+	if val.has_method("set_state"):
+		if name in states:
+			val.set_state(states[name])
+		else:
+			val.set_state("default")
+
+	if val.has_method("set_active"):
+		if name in actives:
+			val.set_active(actives[name])
 
 func get_registered_objects():
 	return objects

--- a/device/globals/trigger.gd
+++ b/device/globals/trigger.gd
@@ -51,15 +51,20 @@ func input(event):
 
 func body_entered(body):
 	if body is esc_type.PLAYER:
-		run_event("enter")
+		if self.visible:
+			run_event("enter")
 
 func body_exited(body):
 	if body is esc_type.PLAYER:
-		run_event("exit")
+		if self.visible:
+			run_event("exit")
 
 func run_event(event):
 	if event in event_table:
 		vm.run_event(event_table[event])
+
+func set_active(p_active):
+	self.visible = p_active
 
 func _ready():
 	var area
@@ -76,6 +81,8 @@ func _ready():
 		var f = File.new()
 		if f.file_exists(events_path):
 			event_table = vm.compile(events_path)
+
+	vm.register_object(global_id, self)
 
 	area.connect("mouse_entered", self, "mouse_enter")
 	area.connect("mouse_exited", self, "mouse_exit")


### PR DESCRIPTION
With this commit, esc scripts can use `set_active` on triggers and exits. Using only visible for this is a much cleaner implementation than adding an extra `active` boolean as I originally did. Thanks to @fleskesvor for the idea!