### PR TITLE
Fix bug in teleporting to target

### DIFF
--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -292,10 +292,11 @@ func _process(time):
 
 
 func teleport(obj):
-	if animations.dir_angles.size() > 0 && obj.interact_angle != -1:
-		last_dir = _get_dir(obj.interact_angle)
-		animation.play(animations.idles[last_dir])
-		pose_scale = animations.idles[last_dir + 1]
+	if animations.dir_angles.size() > 0:
+		if "interact_angle" in obj and obj.interact_angle != -1:
+			last_dir = _get_dir(obj.interact_angle)
+			animation.play(animations.idles[last_dir])
+			pose_scale = animations.idles[last_dir + 1]
 
 	var pos
 	if obj.has_method("get_interact_pos"):


### PR DESCRIPTION
esc_type.TARGET does not have an interact angle so this was
a problem when teleporting a player to one.