### PR TITLE
Allow sched_event to have multi-word events

### DIFF
--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -195,7 +195,18 @@ func dialog_config(params):
 func sched_event(params):
 	var time = params[0]
 	var obj = params[1]
-	var event = params[2]
+	var event
+	if params.size() == 3:
+		event = params[2]
+	else:
+		# This should be easier in Godot 3.1 with array slicing
+		for i in range(2, params.size()):
+			var word = params[i]
+			if not event:
+				event = word
+			else:
+				event += " %s" % word
+
 	if !check_obj(obj, "sched_event"):
 		return
 	var o = vm.get_object(obj)

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -187,6 +187,7 @@ Items can also change state by playing animations from an `AnimationPlayer` name
 
 - `sched_event time object event`
   Schedules the execution of an "event" found in "object" in a time in seconds. If another event is running at the time, execution starts when the running event ends.
+  `event` can consist of multiple words like in `sched_event 0 tow_hook use inv_rope`
 
 - `camera_set_pos speed x y`
   Moves the camera to a position defined by "x" and "y", at the speed defined by "speed" in pixels per second. If speed is 0, camera is teleported to the position.


### PR DESCRIPTION
Because sched_event is so useful for testing, when you temporarily
set a game state in the room's event script, it should be possible
to test an object's `use inventory_item` events as well.

This commit brings that.