### PR TITLE
[RFC] Make player's set_state actually set a state, not just a costume

### DIFF
--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -45,12 +45,9 @@ func anim_finished(anim_name):
 		set_scale(get_scale() * anim_scale_override)
 		anim_scale_override = null
 
-	var cur = animation.get_current_animation()
-
-	# `cur` is always "" for a finished animation,
-	# this forces the state to be reset and the animation played again
-	if cur != state:
-		set_state(state, true)
+	# Although states are permanent until changed, the underlying animations are not,
+	# so we must re-set the state for the appearance of permanence
+	set_state(state, true)
 
 func set_active(p_active):
 	active = p_active
@@ -252,9 +249,8 @@ func set_state(p_state, p_force = false):
 
 	# printt("set state ", "global_id: ", global_id, "state: ", state, "p_state: ", p_state, "p_force: ", p_force)
 
-	if has_node("animation"):
-		get_node("animation").stop()
 	state = p_state
+
 	if animation != null:
 		if animation.is_playing() && animation.get_current_animation() == p_state:
 			return

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -114,11 +114,9 @@ set_globals i/* false
 ```
 
 - `set_state object state`
-  Changes the state of an object, and executes the state animation if present. The command can be used to change the appearance of an item or a player character.
+  Changes the state of an object, and executes the state animation if present. The command can be used to change the appearance of an item. Please see `cut_scene` for changing costumes for NPCs and the player character.
 
-When used on a player object, the command is used to dress the player in a costume identified by the state parameter. An `AnimationPlayer` with the given parameter should be a child of the player node, although one named "animation" is always the fallback when trying set a missing costume.
-
-Items can also change state by playing animations from an `AnimationPlayer` named "animation". The `AnimationPlayer` is typically used to change the texture of a `Sprite` node, but it's also possible to add additional tracks for changing the tooltip and other properties of the item scene. By using keyframes and looping, any given state can also use multiple textures to bring more life to the item.
+Items can change state by playing animations from an `AnimationPlayer` named "animation". The `AnimationPlayer` is typically used to change the texture of a `Sprite` node, but it's also possible to add additional tracks for changing the tooltip and other properties of the item scene. By using keyframes and looping, any given state can also use multiple textures to bring more life to the item.
 
 - `set_hud_visible visible`
   If you have a cut-scene-like sequence where the player doesn't have control, and you also have HUD elements visible, use this to hide the HUD. You want to do that because it explicitly signals the player that there is no control over the game at the moment. "visible" is true or false.
@@ -139,6 +137,10 @@ Items can also change state by playing animations from an `AnimationPlayer` name
   - reverse plays the animation in reverse when true
   - flip_x flips the x axis of the object's sprites when true (object's root node needs to be Node2D)
   - flip_y flips the y axis of the object's sprites when true (object's root node needs to be Node2D)
+
+  You must use this to change the appearance of the player character or an item that has an idle animation (think NPCs), and then explicitly `set_state char idle` for the appearance to come into effect.
+  An `AnimationPlayer` with the given parameter should be a child of the player node, although one named "animation" is always the fallback when trying set a missing costume.
+
 
 - `set_active object value`
   Changes the "active" state of the object, value can be true or false. Inactive objects are hidden in the scene.

--- a/docs/setting_states.md
+++ b/docs/setting_states.md
@@ -1,14 +1,16 @@
 # Setting states
 
 States are a versatile feature of Escoria. They provide a way to use the
-animation interfaces to have the player change costumes and items to
-appear different or transition from static to animated.
+animation interfaces to have items to appear different or transition from
+static to animated.
 
 ## Animated items
 
 The animations are documented in the flossmanuals book, eg.
 [Animations](https://fr.flossmanuals.net/creating-point-and-click-games-with-escoria/animations/)
 and [Main Player](https://fr.flossmanuals.net/creating-point-and-click-games-with-escoria/main-player/) for most of your needs.
+
+Note that for the player character and animated items which "idle", ie. NPCs, you must allow the appearance-changing animation to execute completely by running the `cut_scene` esc command and then running `set_state char idle` for the appearance-change to come into effect.
 
 ## Static items
 


### PR DESCRIPTION
This aligns the behavior with NPC behavior without breaking
how simple items can still be altered with `set_state`. The difference
lies in how idle animations are handled and when the costume
change comes into effect.

Therefore a character's costume change must be a combination of
`cut_scene` to allow the costume change animation to finish and then
an explicit `set_state char idle` or whatever you want your character to
do next.