### PR TITLE
Fix dialog

### DIFF
--- a/device/globals/dialog_player.gd
+++ b/device/globals/dialog_player.gd
@@ -10,7 +10,7 @@ func say(params, callback):
 		type = params[2]
 	type = type + ProjectSettings.get_setting("escoria/platform/dialog_type_suffix")
 	var inst = get_resource(type).instance()
-	get_parent().add_child(inst)
+	get_node("/root").get_child(0).add_child(inst)
 	var intro = true
 	var outro = true
 	if type in types:

--- a/device/globals/game.tscn
+++ b/device/globals/game.tscn
@@ -1,15 +1,18 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://globals/game.gd" type="Script" id=1]
+[ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=2]
 
-[node name="game" type="Node" index="0"]
+[node name="game" type="Node"]
 
 script = ExtResource( 1 )
 fallbacks_path = "res://demo/fallbacks.esc"
 inventory_enabled = true
 camera_limits = Rect2( 0, 0, 0, 0 )
 
-[node name="hud_layer" type="CanvasLayer" parent="." index="0"]
+[node name="dialog_player" parent="." index="0" instance=ExtResource( 2 )]
+
+[node name="hud_layer" type="CanvasLayer" parent="." index="1"]
 
 layer = 1
 offset = Vector2( 0, 0 )
@@ -19,14 +22,16 @@ transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
 [node name="hud" parent="hud_layer" index="0" instance_placeholder="res://ui/hud.tscn"]
 
-[node name="wait_timer" type="Timer" parent="." index="1"]
+mouse_default_cursor_shape = 0
+
+[node name="wait_timer" type="Timer" parent="." index="2"]
 
 process_mode = 1
 wait_time = 1.0
 one_shot = false
 autostart = false
 
-[node name="camera" type="Camera2D" parent="." index="2"]
+[node name="camera" type="Camera2D" parent="." index="3"]
 
 anchor_mode = 1
 rotating = false

--- a/device/globals/game_am.tscn
+++ b/device/globals/game_am.tscn
@@ -1,34 +1,34 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://globals/game.gd" type="Script" id=1]
+[ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=2]
 
-[node name="game" type="Node" index="0"]
+[node name="game" type="Node"]
 
 script = ExtResource( 1 )
 fallbacks_path = "res://demo/fallbacks.esc"
 inventory_enabled = true
 camera_limits = Rect2( 0, 0, 0, 0 )
 
-[node name="hud_layer" type="CanvasLayer" parent="." index="0"]
+[node name="dialog_player" parent="." index="0" instance=ExtResource( 2 )]
+
+[node name="hud_layer" type="CanvasLayer" parent="." index="1"]
 
 layer = 1
 offset = Vector2( 0, 0 )
 rotation = 0.0
 scale = Vector2( 1, 1 )
-transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
 [node name="hud" parent="hud_layer" index="0" instance_placeholder="res://ui/hud_minimal.tscn"]
 
-mouse_default_cursor_shape = 0
-
-[node name="wait_timer" type="Timer" parent="." index="1"]
+[node name="wait_timer" type="Timer" parent="." index="2"]
 
 process_mode = 1
 wait_time = 1.0
 one_shot = false
 autostart = false
 
-[node name="camera" type="Camera2D" parent="." index="2"]
+[node name="camera" type="Camera2D" parent="." index="3"]
 
 anchor_mode = 1
 rotating = false
@@ -43,8 +43,6 @@ drag_margin_h_enabled = true
 drag_margin_v_enabled = true
 smoothing_enabled = false
 smoothing_speed = 5.0
-offset_v = 0.0
-offset_h = 0.0
 drag_margin_left = 0.2
 drag_margin_top = 0.2
 drag_margin_right = 0.2

--- a/device/globals/main.tscn
+++ b/device/globals/main.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://globals/main.gd" type="Script" id=1]
 [ext_resource path="res://globals/bg_music.tscn" type="PackedScene" id=2]
-[ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=3]
-[ext_resource path="res://ui/dd_player.tscn" type="PackedScene" id=4]
+[ext_resource path="res://ui/dd_player.tscn" type="PackedScene" id=3]
 
-[node name="main" type="Node"]
+[node name="main" type="Node" index="0"]
 
 pause_mode = 2
 script = ExtResource( 1 )
@@ -23,8 +22,6 @@ transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 [node name="bg_music" parent="layers/telon" index="0" instance=ExtResource( 2 )]
 
 rect_clip_content = false
-interact_position = null
-dialog_color = null
 
 [node name="telon" parent="layers/telon" index="1" instance_placeholder="res://globals/telon.tscn"]
 
@@ -38,9 +35,7 @@ rotation = 0.0
 scale = Vector2( 1, 1 )
 transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
-[node name="dialog_player" parent="layers/dialog" index="0" instance=ExtResource( 3 )]
-
-[node name="dd_player" parent="layers/dialog" index="1" instance=ExtResource( 4 )]
+[node name="dd_player" parent="layers/dialog" index="0" instance=ExtResource( 3 )]
 
 [node name="menu" type="CanvasLayer" parent="layers" index="2"]
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -19,40 +19,16 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 script = ExtResource( 1 )
 
-[node name="inventory" parent="." index="0" instance=ExtResource( 2 )]
-
-modulate = Color( 1, 1, 1, 1 )
-self_modulate = Color( 0, 0, 0, 0.196078 )
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -620.0
-margin_top = -400.0
-margin_right = -20.0
-margin_bottom = -100.0
-texture = ExtResource( 3 )
-
-[node name="verb_menu" parent="." index="1" instance=ExtResource( 4 )]
-
-anchor_top = 1.0
-anchor_bottom = 1.0
-margin_left = 20.0
-margin_top = -260.0
-margin_right = 0.0
-margin_bottom = 0.0
-mouse_default_cursor_shape = 0
-
-[node name="tooltip" type="Label" parent="." index="2"]
+[node name="tooltip" type="Label" parent="." index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_left = 160.0
-margin_top = -842.0
+margin_top = 58.0
 margin_right = 1149.0
-margin_bottom = -785.0
+margin_bottom = 115.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 2
@@ -65,5 +41,31 @@ valign = 1
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
+_sections_unfolded = [ "Visibility" ]
+
+[node name="inventory" parent="." index="1" instance=ExtResource( 2 )]
+
+modulate = Color( 1, 1, 1, 1 )
+self_modulate = Color( 0, 0, 0, 0.196078 )
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -620.0
+margin_top = -400.0
+margin_right = -20.0
+margin_bottom = -100.0
+texture = ExtResource( 3 )
+_sections_unfolded = [ "Anchor", "Margin", "Rect", "Visibility" ]
+
+[node name="verb_menu" parent="." index="2" instance=ExtResource( 4 )]
+
+anchor_top = 1.0
+anchor_bottom = 1.0
+margin_left = 20.0
+margin_top = -260.0
+margin_right = 0.0
+margin_bottom = 0.0
+mouse_default_cursor_shape = 0
 
 

--- a/device/ui/hud.tscn
+++ b/device/ui/hud.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://globals/hud.gd" type="Script" id=1]
 [ext_resource path="res://demo/ui/inventory.tscn" type="PackedScene" id=2]
-[ext_resource path="res://globals/white.png" type="Texture" id=3]
-[ext_resource path="res://demo/ui/verb_menu.tscn" type="PackedScene" id=4]
+[ext_resource path="res://demo/ui/verb_menu.tscn" type="PackedScene" id=3]
 
 [node name="hud" type="Control" index="0"]
 
@@ -19,16 +18,38 @@ size_flags_horizontal = 2
 size_flags_vertical = 2
 script = ExtResource( 1 )
 
-[node name="tooltip" type="Label" parent="." index="0"]
+[node name="inventory" parent="." index="0" instance=ExtResource( 2 )]
 
-anchor_left = 0.0
-anchor_top = 0.0
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 160.0
-margin_top = 58.0
-margin_right = 1149.0
-margin_bottom = 115.0
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -620.0
+margin_top = -400.0
+margin_right = -20.0
+margin_bottom = -100.0
+_sections_unfolded = [ "Anchor", "Margin", "Rect", "Visibility" ]
+
+[node name="verb_menu" parent="." index="1" instance=ExtResource( 3 )]
+
+anchor_top = 1.0
+anchor_bottom = 1.0
+margin_left = 20.0
+margin_top = -260.0
+margin_right = 0.0
+margin_bottom = 0.0
+mouse_default_cursor_shape = 0
+
+[node name="tooltip" type="Label" parent="." index="2"]
+
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -494.5
+margin_top = -842.0
+margin_right = 494.5
+margin_bottom = -785.0
 rect_pivot_offset = Vector2( 0, 0 )
 rect_clip_content = false
 mouse_filter = 2
@@ -41,31 +62,6 @@ valign = 1
 percent_visible = 1.0
 lines_skipped = 0
 max_lines_visible = -1
-_sections_unfolded = [ "Visibility" ]
-
-[node name="inventory" parent="." index="1" instance=ExtResource( 2 )]
-
-modulate = Color( 1, 1, 1, 1 )
-self_modulate = Color( 0, 0, 0, 0.196078 )
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -620.0
-margin_top = -400.0
-margin_right = -20.0
-margin_bottom = -100.0
-texture = ExtResource( 3 )
-_sections_unfolded = [ "Anchor", "Margin", "Rect", "Visibility" ]
-
-[node name="verb_menu" parent="." index="2" instance=ExtResource( 4 )]
-
-anchor_top = 1.0
-anchor_bottom = 1.0
-margin_left = 20.0
-margin_top = -260.0
-margin_right = 0.0
-margin_bottom = 0.0
-mouse_default_cursor_shape = 0
+_sections_unfolded = [ "Margin", "Visibility" ]
 
 


### PR DESCRIPTION
This reverts the change that placed the dialog player into a canvas layer in main.tscn, since unless position was fixed, dialog would be placed outside of the viewport in most cases, because of the difference between the scene size and the actual size of the viewport. There would have to be code in place to calculate position from the ratio between the two, but the previous solution is likely more predictable.