### PR TITLE
Clean up item states, especially useful for NPCs

### DIFF
--- a/device/globals/interactive.gd
+++ b/device/globals/interactive.gd
@@ -46,8 +46,7 @@ func walk_stop(pos):
 	set_position(pos)
 	walk_path = []
 
-	if animation != null && animation.is_playing():
-		animation.stop()
+	# Walking is not a state, but we must re-set our previous state to reset the animation
 	set_state(state)
 
 	task = null


### PR DESCRIPTION
In interactive.gd, don't stop a playing animation, but let item.gd
do that. Having a stopped animation can lead to weird side effects,
which I can't explain, but where `state` is set though
`animation.get_current_animation()` returns `""`.

Now there's no need to call `animation.stop()` before setting a state,
so that's cleaner. I also cleaned up some of the `get_node("animation")`
mess because that's already bound to a variable anyway.