### PR TITLE
Revert "Move `dialog_default` out of demo as a `Container`"

### DIFF
--- a/device/demo/ui/dialog_default.tscn
+++ b/device/demo/ui/dialog_default.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://demo/ui/dialog_theme.tres" type="Theme" id=2]
 
 
-[node name="dialog_instance" type="Container"]
+[node name="dialog_instance" type="Node2D"]
 
 anchor_left = 0.0
 anchor_top = 0.0
@@ -24,7 +24,7 @@ typewriter_text = true
 characters_per_second = 45.0
 fixed_pos = false
 
-[node name="anchor" type="Container" parent="." index="0"]
+[node name="anchor" type="Node2D" parent="." index="0"]
 
 anchor_left = 0.0
 anchor_top = 0.0

--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -1,4 +1,4 @@
-extends Container
+extends Node2D
 
 var context
 var text

--- a/device/globals/dialog_player.gd
+++ b/device/globals/dialog_player.gd
@@ -10,6 +10,7 @@ func say(params, callback):
 		type = params[2]
 	type = type + ProjectSettings.get_setting("escoria/platform/dialog_type_suffix")
 	var inst = get_resource(type).instance()
+	var z = inst.get_z_index()
 	get_node("/root").get_child(0).add_child(inst)
 	var intro = true
 	var outro = true
@@ -17,6 +18,7 @@ func say(params, callback):
 		intro = types[type][0]
 		outro = types[type][1]
 	inst.init(params, callback, intro, outro)
+	inst.set_z_index(z)
 
 func config(params):
 	types[params[0]] = [params[1], params[2]]


### PR DESCRIPTION
This reverts commit 28dea4d2ad5662dc2f27565c972965a68a79d1a2.

Because canvas layers didn't happen yet, a Container with the
dialog will be below regular items. My gut, and experimenting
with the ordering in the scene tree, tells me that this is
how it's supposed to work. Either you use Z or a separate
canvas layer.