### PR TITLE
Settings for HiDPI/Retina, fix aspect ratio

### DIFF
--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -88,34 +88,6 @@ func wait(time, level):
 	wait_timer.set_one_shot(true)
 	wait_timer.start()
 
-func check_screen():
-#	var vs = OS.get_video_mode_size()
-	var vs = OS.get_screen_size()
-	if vs == vm_size:
-		return
-	vm_size = vs
-
-	var rate = float(vs.x)/float(vs.y)
-	var height = int(game_size.x / rate)
-	get_node("/root").set_size_override(true,Vector2(game_size.x,height))
-	get_node("/root").set_size_override_stretch(true)
-
-	var m = Transform2D()
-	var ofs = Vector2(0, (height - game_size.y) / 2)
-	m.origin = ofs
-	get_node("/root").global_canvas_transform = m
-
-	screen_ofs = ofs
-	printt("**** screen ofs is ", screen_ofs)
-
-	#get_tree().set_auto_accept_quit(false)
-
-	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "set_camera_limits")
-
-
-func _process(time):
-	check_screen()
-
 func _input(event):
 	# CTRL+F12
 	if (event is InputEventKey and event.pressed and event.control and event.scancode==KEY_F12):

--- a/device/project.godot
+++ b/device/project.godot
@@ -25,6 +25,9 @@ window/size/width=1920
 window/size/height=1080
 window/size/test_width=1920
 window/size/test_height=1080
+window/dpi/allow_hidpi=true
+window/stretch/mode="2d"
+window/stretch/aspect="expand"
 
 [escoria]
 


### PR DESCRIPTION
Although the documentation for
[Multiple Settings](http://docs.godotengine.org/en/3.0/tutorials/viewports/multiple_resolutions.html)
makes it sound like the `Expand` aspect ratio doesn't do
what we want, godotengine/godot#19912 states that this is the correct way.

~Further documentation may be warranted for the scene tree to
avoid having a clear-color bar at the top of a Retina game.~

~This commit does not yet address that documentation.~

It appears that it was a bug in Escoria that caused the problems with other aspect ratios.