### PR TITLE
Option for items to set only z-index from scalemap

### DIFF
--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -13,7 +13,7 @@ export(Color) var dialog_color = null
 export var talk_animation = "talk"
 export var active = true setget set_active,get_active
 export var placeholders = {}
-export var use_custom_z = false
+export var dynamic_z_index = true
 
 var anim_notify = null
 var anim_scale_override = null
@@ -268,8 +268,9 @@ func teleport_pos(x, y):
 	_update_terrain()
 
 func _update_terrain():
-	if self is Node2D && !use_custom_z:
+	if self is Node2D and dynamic_z_index:
 		set_z_index(get_position().y)
+
 	if !scale_on_map && !light_on_map:
 		return
 
@@ -278,6 +279,7 @@ func _update_terrain():
 	var terrain = $"../terrain" if has_node("../terrain") else null
 	if terrain == null:
 		return
+
 	var color = terrain.get_terrain(pos)
 	var scale_range = terrain.get_scale_range(color.b)
 
@@ -286,7 +288,7 @@ func _update_terrain():
 	# to flip a node is multiply its x-axis scale.
 	scale_range.x *= pose_scale
 
-	if scale_on_map && (self is Node2D) && scale_range != get_scale():
+	if self is Node2D and scale_on_map and scale_range != get_scale():
 		# Check if `interact_pos` is a child of ours, and if so,
 		# take a backup of the global position, because it will be affected by scaling.
 		var interact_global_position
@@ -300,7 +302,7 @@ func _update_terrain():
 		if interact_global_position:
 			interact_pos.global_position = interact_global_position
 
-	if light_on_map:
+	if self is CanvasItem and light_on_map:
 		var c = terrain.get_light(pos)
 		modulate(c)
 

--- a/docs/items.md
+++ b/docs/items.md
@@ -20,7 +20,17 @@ It may be that you want these default actions to require double-clicks. This is 
 
 An item-local default action overrides a global default action, as you'd expect.
 
-### Background items
+## Z-index
+
+By default every room in the game is considered to have faux "depth". This is done by setting the z-index based on the y-coordinate.
+
+If you want things to be flat or manually controlled, you can use Godot's z-indexes by unchecking the `Dynamic Z Index` checkbox.
+At least for certain inventory configurations, this is something you must do. If your items don't show up on the HUD, uncheck!
+
+The system isn't perfect, so sometimes you may have to use an `AnimationPlayer` to tweak the z-index given by Godot. Likewise
+if your item consists of many nodes, they will have different positions, so some of them may need manual tweaking.
+
+## Background items
 
 There are also times when you want to enable the player to interact with items which are not separate scenes, but drawn directly on the background. For such use cases, you will typically use a `TextureRect` to frame the item, with an optional click mask, and no "area" child node.
 
@@ -33,7 +43,7 @@ You can also use an `Area2D` for your background item with a `CollisionPolygon2D
     * `CollisionPolygon2D` which defines the shape of the item
     * ...
 
-### Parallax items
+## Parallax items
 
 Items can also be added to a parallax layer, but this comes with a few caveats. First of all, you need to use an item with the shape defined by a `Control` node, since the mouse cursor cannot interact with an `Area2D` through the foreground layer. Secondly, since these items will be visible to the cursor through the foreground, any items meant to be obstructed by foreground elements will need to be masked by a `Control` node. These masks don't need to be items, but can be `TextureRects` with click masks for more fine grained control of their shape. Do take care not to cover any items in the foreground with these masks though, as that will make them impossible to interact with.
 


### PR DESCRIPTION
This de-couples z-indexing from scaling. The use case is when
gfx artists draws a room with different "element items" as layers
in the same scale, and using the sizemap to get the z-index would
shrink the item.

The alternative to this is to debug what the scale factor is,
divide 1 by it, multiply by 100, scale that image separately,
and have it look ridiculously yet uselessly big in the editor.

Now it's possible to retain the artist's scales but also have
the player move behind the element item!