### PR TITLE
Fix item's error about missing terrain

### DIFF
--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -273,7 +273,8 @@ func _update_terrain():
 		return
 
 	var pos = get_position()
-	var terrain = get_node("../terrain")
+	# Items in the scene tree will issue errors unless this is conditional
+	var terrain = $"../terrain" if has_node("../terrain") else null
 	if terrain == null:
 		return
 	var color = terrain.get_terrain(pos)


### PR DESCRIPTION
The error seems benign and temporary, probably related to
how the scene node tree is set up, so just checking `has_node()`
in advance makes it behave better.