### PR TITLE
Overload _find_sprites() to look for anything to modulate

### DIFF
--- a/device/globals/interactive.gd
+++ b/device/globals/interactive.gd
@@ -144,7 +144,7 @@ func set_angle(deg):
 		_update_terrain()
 
 func _find_sprites(p = null):
-	if p is Sprite || p is AnimatedSprite || p is TextureRect || p is TextureButton:
+	if p is CanvasItem:
 		sprites.push_back(p)
 	for i in range(0, p.get_child_count()):
 		_find_sprites(p.get_child(i))

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -340,7 +340,7 @@ func set_angle(deg):
 
 
 func _find_sprites(p = null):
-	if p is Sprite || p is AnimatedSprite:
+	if p is CanvasItem:
 		sprites.push_back(p)
 	for i in range(0, p.get_child_count()):
 		_find_sprites(p.get_child(i))


### PR DESCRIPTION
This is because eg. Spine nodes, although not officially supported,
are inherited from CanvasItem. In fact, CanvasItem is what implements
light modulation, and `_find_sprites()` is used for nothing else,
it makes sense to apply the light map everywhere.