### PR TITLE
Fix crash when clicking Polygon2D

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -170,6 +170,7 @@ func clicked(obj, pos, input_event = null):
 		walk_context = {"fast": input_event.doubleclick}
 
 	# If a background is covered by an item, the item "wins"
+	# and the winning item is chosen in item.gd by looking at the overlapping areas
 	if obj is esc_type.BACKGROUND:
 		var overlay = obj.get_child(0)  # Created by background.gd to intercept clicks
 		# Eg. Polygon2D does not have this method

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -171,9 +171,12 @@ func clicked(obj, pos, input_event = null):
 
 	# If a background is covered by an item, the item "wins"
 	if obj is esc_type.BACKGROUND:
-		for area in obj.get_child(0).get_overlapping_areas():
-			if area.has_method("is_clicked") and area.is_clicked():
-				return
+		var overlay = obj.get_child(0)  # Created by background.gd to intercept clicks
+		# Eg. Polygon2D does not have this method
+		if overlay.has_method("get_overlapping_areas"):
+			for area in overlay.get_overlapping_areas():
+				if area.has_method("is_clicked") and area.is_clicked():
+					return
 
 	# Hide the action menu (where available) when performing actions, so it's not eg. open while walking
 	if action_menu:

--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -96,6 +96,19 @@ func input(event):
 	# TODO: Expand this for other input events than mouse
 	if event is InputEventMouseButton || event.is_action("ui_accept"):
 		if event.is_pressed():
+			# See if we're allowed to call game.gd's `clicked()` method.
+			var bg = $"/root/scene/background"
+			var overlay = bg.get_child(0)  # Created by background.gd to intercept clicks
+
+			# Eg. Polygon2D does not have this method
+			if overlay.has_method("get_overlapping_areas"):
+				var overlapping_areas = overlay.get_overlapping_areas()
+
+				# The last overlapping area is the lowest in the node tree, it gets the event
+				# but verify `self` is contested by other areas, because eg. inventory items aren't
+				if self in overlapping_areas and self != overlapping_areas[-1]:
+					return
+
 			clicked = true
 
 			if event.button_index == BUTTON_LEFT:


### PR DESCRIPTION
If you have a Polygon2D in the scene and click it, Escoria
would call `get_overlapping_areas()` on it, which does not exist.

Address this by checking the method's existence before calling.