### PR TITLE
Show tooltip, as controlled by AM, only when it has text

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -88,9 +88,10 @@ func mouse_enter(obj):
 			vm.hover_begin(obj)
 	else:
 		if current_action != "" && current_tool != null:
-			text = tr(current_action + ".combine_id")
-			text = text.replace("%2", tr(tt))
-			text = text.replace("%1", tr(current_tool.get_tooltip()))
+			if tt:
+				text = tr(current_action + ".combine_id")
+				text = text.replace("%2", tr(tt))
+				text = text.replace("%1", tr(current_tool.get_tooltip()))
 		elif obj.inventory:
 			if !current_action:
 				text = tr(tt)

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -16,7 +16,7 @@ func set_tooltip(text):
 
 func set_tooltip_visible(p_visible):
 	if $"tooltip":
-		$"tooltip".visible = p_visible
+		$"tooltip".visible = p_visible and $"tooltip".text
 
 func inv_toggle():
 	#get_node("inventory").toggle()


### PR DESCRIPTION
The action-menu code interacts with showing the tooltip,
and if an item doesn't have tooltip text, but the tooltip
is configured to have a background, an empty background
would show up without this.

It's annoying and fortunately fixed now.