### PR TITLE
Fix save load states

### DIFF
--- a/device/demo/game.esc
+++ b/device/demo/game.esc
@@ -1,3 +1,3 @@
-:load
+:start
 
 change_scene res://demo/rooms/test/test.tscn

--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -27,7 +27,7 @@ var commands = {
 	"walk_block": { "min_args": 2 },
 	"turn_to": { "min_args": 2 },
 	"set_angle": { "min_args": 2 },
-	"change_scene": { "min_args": 1 },
+	"change_scene": { "min_args": 1, "types": [TYPE_STRING, TYPE_BOOL] },
 	"spawn": { "min_args": 1 },
 	"%": { "alias": "label", "min_args": 1},
 	"jump": { "min_args": 1 },

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -405,6 +405,8 @@ func get_registered_objects():
 	return objects
 
 func set_state(name, state):
+	if !(name in objects):
+		report_errors("global_vm", ["Trying to set state that does not exist:" + name + ": " + state])
 	states[name] = state
 
 func set_active(name, active):
@@ -493,10 +495,10 @@ func can_interact():
 func finished(context):
 	context.waiting = false
 
-func change_scene(params, context):
+func change_scene(params, context, run_events=true):
 	# It might be tempting to use `get_tree().change_scene(params[0])`,
 	# but this custom solution is safer around your scene structure
-	printt("change scene to ", params[0])
+	printt("change scene to ", params[0], " with run_events ", run_events)
 	#var res = ResourceLoader.load(params[0])
 	check_cache()
 	main.clear_scene()
@@ -506,7 +508,7 @@ func change_scene(params, context):
 	res_cache.clear()
 	var scene = res.instance()
 	if scene:
-		main.set_scene(scene)
+		main.set_scene(scene, run_events)
 	else:
 		report_errors("", ["Failed loading scene "+params[0]+" for change_scene"])
 
@@ -615,6 +617,10 @@ func save():
 
 	ret.append("cut_scene telon fade_out\n\n")
 
+	# Change the scene up-front so objects and states can be loaded properly,
+	# and with events disabled to not confuse the game
+	ret.append("change_scene " + main.get_current_scene().get_filename() + " false\n\n")
+
 	ret.append("## Global flags\n\n")
 	for k in globals.keys():
 		if !globals[k]:
@@ -641,21 +647,25 @@ func save():
 		ret.append("\n")
 
 	# check global states of moved objects
-	#for k in objects:
-	#	if k == "player" || objects[k] == null:
-	#		continue
-	#	if objects[k].moved:
-	#		var pos = objects[k].get_position()
-	#		ret.append("teleport_pos " + k + " " + str(int(pos.x)) + " " + str(int(pos.y)) + "\n")
+	for k in objects:
+		if k == "player" || objects[k] == null:
+			continue
+
+		if "moved" in objects[k] and objects[k].moved:
+			var pos = objects[k].get_position()
+			ret.append("teleport_pos " + k + " " + str(int(pos.x)) + " " + str(int(pos.y)) + "\n")
+			if objects[k].last_deg != null:
+				ret.append("set_angle " + k + " " + str(objects[k].last_deg) + "\n")
 
 	ret.append("\n")
 	ret.append("## Player\n\n")
 
-	ret.append("change_scene " + main.get_current_scene().get_filename() + "\n")
-
 	if main.get_current_scene().has_node("player"):
-		var pos = main.get_current_scene().get_node("player").get_global_position()
+		var player = main.get_current_scene().get_node("player")
+		var pos = player.get_global_position()
+		var angle = player.last_deg
 		ret.append("teleport_pos player " + str(pos.x) + " " + str(pos.y) + "\n")
+		ret.append("set_angle player " + str(angle) + "\n")
 
 	if cam_target != null:
 		ret.append("\n")

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -581,10 +581,15 @@ func load_file(p_game):
 	# `load` and `ready` are exclusive because you probably don't want to
 	# reset the game state when a scene becomes ready, and `ready` is
 	# redundant when `load`ing state anyway.
+	# `start` is used only in your `game.esc` file to start the game.
 	if "load" in game:
 		clear()
 		loading_game = true
 		run_event(game["load"])
+		main.menu_collapse()
+	elif "start" in game:
+		clear()
+		run_event(game["start"])
 		main.menu_collapse()
 	elif "ready" in game:
 		run_event(game["ready"])

--- a/device/globals/interactive.gd
+++ b/device/globals/interactive.gd
@@ -6,6 +6,7 @@ var walk_path
 var walk_context
 var moved
 var last_scale = Vector2(1, 1)
+var last_deg = null
 var last_dir = 0
 var animation
 var state = ""
@@ -134,6 +135,9 @@ func turn_to(deg):
 	if deg < 0 or deg > 360:
 		vm.report_errors("interactive", ["Invalid degree to turn to " + str(deg)])
 
+	moved = true
+
+	last_deg = deg
 	last_dir = _get_dir_deg(deg)
 
 	if animation:
@@ -146,6 +150,9 @@ func set_angle(deg):
 	if deg < 0 or deg > 360:
 		vm.report_errors("interactive", ["Invalid degree to turn to " + str(deg)])
 
+	moved = true
+
+	last_deg = deg
 	last_dir = _get_dir_deg(deg)
 
 	if animations and "idles" in animations:

--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -261,10 +261,12 @@ func set_state(p_state, p_force = false):
 
 func teleport(obj):
 	set_position(obj.global_position)
+	moved = true
 	_update_terrain(self is Node2D)
 
 func teleport_pos(x, y):
 	set_position(Vector2(x, y))
+	moved = true
 	_update_terrain(self is Node2D)
 
 func _update_terrain(need_z_update=false):

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -21,14 +21,15 @@ func clear_scene():
 	current.free()
 	current = null
 
-func set_scene(p_scene):
+func set_scene(p_scene, run_events=true):
 	if current != null:
 		clear_scene()
 
 	if !p_scene:
 		return
 	get_node("/root").add_child(p_scene)
-	set_current_scene(p_scene)
+	# The null is for events_path; it has to be explicit because gdscript lacks keyword arguments
+	set_current_scene(p_scene, null, run_events)
 
 func get_current_scene():
 	return current
@@ -71,12 +72,13 @@ func menu_collapse():
 		i -= 1
 		menu_stack[i].menu_collapsed()
 
-func set_current_scene(p_scene, events_path=null):
+func set_current_scene(p_scene, events_path=null, run_events=true):
 	#print_stack()
 	current = p_scene
 	get_node("/root").move_child(p_scene, 0)
 
-	if events_path:
+	# Loading a save game must set the scene but not run events
+	if events_path and run_events:
 		vm.load_file(events_path)
 
 func wait_finished():

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -14,6 +14,7 @@ export var speed = 300
 export var v_speed_damp = 1.0
 export(Script) var animations
 export(Color) var dialog_color = null
+var last_deg = null
 var last_dir = 0
 var last_scale
 var pose_scale = 1
@@ -291,6 +292,7 @@ func _process(time):
 		var angle = (old_pos.angle_to_point(pos)) * -1
 		set_position(pos)
 
+		last_deg = rad2deg(angle)
 		last_dir = _get_dir(angle)
 
 		if animation.get_current_animation() != animations.directions[last_dir]:
@@ -303,6 +305,7 @@ func _process(time):
 func teleport(obj):
 	if animations.dir_angles.size() > 0:
 		if "interact_angle" in obj and obj.interact_angle != -1:
+			last_deg = obj.interact_angle
 			last_dir = _get_dir_deg(obj.interact_angle)
 			animation.play(animations.idles[last_dir])
 			pose_scale = animations.idles[last_dir + 1]
@@ -334,6 +337,7 @@ func turn_to(deg):
 	if deg < 0 or deg > 360:
 		vm.report_errors("player", ["Invalid degree to turn to " + str(deg)])
 
+	last_deg = deg
 	last_dir = _get_dir_deg(deg)
 
 	if animation.get_current_animation() != animations.directions[last_dir]:
@@ -345,6 +349,7 @@ func set_angle(deg):
 	if deg < 0 or deg > 360:
 		vm.report_errors("player", ["Invalid degree to turn to " + str(deg)])
 
+	last_deg = deg
 	last_dir = _get_dir_deg(deg)
 
 	pose_scale = animations.idles[last_dir+1]

--- a/device/globals/scene_base.gd
+++ b/device/globals/scene_base.gd
@@ -3,5 +3,8 @@ extends Node
 export(String, FILE, ".esc") var events_path = ""
 
 func _ready():
-	main.call_deferred("set_current_scene", self, events_path)
+	# XXX: Why is this call required?
+	# Running the events when loading a game messes the game state completely, don't do it
+	var run_events = not vm.loading_game
+	main.call_deferred("set_current_scene", self, events_path, run_events)
 

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -178,9 +178,9 @@ func change_scene(params):
 	var sep = params[0].find(":\"")
 	if sep >= 0:
 		var path = params[0].substr(sep + 2, params[0].length() - (sep + 2))
-		vm.call_deferred("change_scene", [path], current_context)
+		vm.call_deferred("change_scene", [path], current_context, run_events)
 	else:
-		vm.call_deferred("change_scene", params, current_context)
+		vm.call_deferred("change_scene", params, current_context, run_events)
 
 	current_context.waiting = true
 	return vm.state_yield

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -169,6 +169,11 @@ func set_angle(params):
 	return vm.state_return
 
 func change_scene(params):
+	# Savegames must have events disabled, so saving the game adds a false to params
+	var run_events = true
+	if params.size() == 2:
+		run_events = bool(params[1])
+
 	# looking for localized string format in scene. this should be somewhere else
 	var sep = params[0].find(":\"")
 	if sep >= 0:

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -149,8 +149,8 @@ Items can also change state by playing animations from an `AnimationPlayer` name
 - `wait seconds`
   Blocks execution of the current script for a number of seconds specified by the "seconds" parameter.
 
-- `change_scene path`
-  Loads a new scene, specified by "path"
+- `change_scene path run_events`
+  Loads a new scene, specified by "path". The `run_events` variable is a boolean (default true) which you never want to set manually! It's there only to benefit save games, so they don't conflict with the scene's events.
 
 - `set_speed object speed`
   Sets how fast object moves. It must use the `interactive.gd` script or something extended from it. Value is an integer.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ Installation
 Reference
 ---------
 
+[How a game is started](starting-a-game.md)
+
 [Background](background.md)
 
 [Designing dialogs](designing_dialogs.md)

--- a/docs/starting-a-game.md
+++ b/docs/starting-a-game.md
@@ -1,0 +1,19 @@
+# Starting a game
+
+Escoria looks for a start script for your game.
+
+You can configure its path in `platform/game_start_script`.
+
+It should look like this
+
+```
+:start
+    change_scene res://game-dir/rooms/your-first-room/scene.tscn
+```
+
+Note that the `:start` event is not used anywhere else. The start script
+does not use `:load`, because loading save games has to disable events. So
+if `:load` was used, your legitimate events at the start of your game would
+not work. And not checking for game loads would completely break your game
+every time you load a save!
+


### PR DESCRIPTION
I noticed an anomaly in A Lunar Adventure when continuing an old game.

Room 3 features an NPC going off to do his thing, but when loading, he stands at the start position.

This fixes the situation.
