### PR TITLE
Remove inline comments from ESC commands

### DIFF
--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -331,6 +331,12 @@ func read_cmd(state, level, errors):
 		return
 	else:
 		params.remove(0)
+
+		# Remove inline comments
+		var comment_idx = params.find("#")
+		if comment_idx > -1:
+			params.resize(comment_idx)
+
 		cmd.params = params
 		read_line(state)
 


### PR DESCRIPTION
It's annoying that depending on the command, inline comments may be ignored in later parsing and sometimes they cause side-effects when the second (or _n_ th) argument.

Just get rid of them up-front.