### PR TITLE
Refactor/streamline player's set_state for costumes

### DIFF
--- a/device/demo/actors/player/player.tscn
+++ b/device/demo/actors/player/player.tscn
@@ -404,7 +404,7 @@ tracks/1/keys = {
 custom_solver_bias = 0.0
 extents = Vector2( 10, 10 )
 
-[node name="player" type="KinematicBody2D"]
+[node name="player" type="KinematicBody2D" index="0"]
 
 input_pickable = false
 collision_layer = 1
@@ -427,7 +427,7 @@ position = Vector2( 5.2803, -49.2264 )
 frames = SubResource( 1 )
 animation = "hat"
 
-[node name="animation" type="AnimationPlayer" parent="." index="1"]
+[node name="default" type="AnimationPlayer" parent="." index="1"]
 
 root_node = NodePath("..")
 autoplay = ""

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -100,7 +100,12 @@ func anim_get_ph_paths(p_anim):
 	return ret
 
 func play_anim(p_anim, p_notify = null, p_reverse = false, p_flip = null):
-	if p_notify != null && (!has_node("animation") || !get_node("animation").has_animation(p_anim)):
+	if not animation:
+		vm.report_errors("player", ["Animation not found for play_anim"])
+	if not animation.has_animation(p_anim):
+		vm.report_errors("player", [animation.name + " does not contain " + p_anim])
+
+	if p_notify != null && (!animation || !animation.has_animation(p_anim)):
 		vm.finished(p_notify)
 		return
 
@@ -125,10 +130,9 @@ func play_anim(p_anim, p_notify = null, p_reverse = false, p_flip = null):
 		anim_scale_override = null
 
 	if p_reverse:
-		get_node("animation").play(p_anim, -1, -1, true)
+		animation.play(p_anim, -1, -1, true)
 	else:
-		get_node("animation").play(p_anim)
-		#get_node("animation").seek(0, true)
+		animation.play(p_anim)
 
 	anim_notify = p_notify
 	var dir = _find(p_anim, animations.directions, p_flip.x)
@@ -359,11 +363,17 @@ func _ready():
 
 	vm = $"/root/vm"
 
-	if has_node("animation"):
-		animation = $"animation"
-		animation.connect("animation_finished", self, "anim_finished")
+	if has_node("default"):
+		animation = $"default"
+
 		if not animations:
 			vm.report_errors("player", ["Animations not set for player."])
+	else:
+		vm.report_errors("player", ["No default AnimationPlayer found"])
+
+	for child in get_children():
+		if child is AnimationPlayer:
+			child.connect("animation_finished", self, "anim_finished")
 
 	vm.register_object("player", self)
 

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -308,9 +308,12 @@ func teleport(obj):
 	_update_terrain()
 
 func set_state(costume):
-	var node = get_node(costume)
-	# You can `set_state player default` with no animation by that name, and get "animation"
-	animation = node if node else $"animation"
+	# Set a costume-state by changing the AnimationPlayer.
+	if has_node(costume):
+		animation = get_node(costume)
+	else:
+		vm.report_errors("player", ["Costume AnimationPlayer '" + costume + "' not found"])
+
 	assert(animation is AnimationPlayer)
 	animation.play(animations.idles[last_dir])
 

--- a/docs/setting_states.md
+++ b/docs/setting_states.md
@@ -10,6 +10,8 @@ The animations are documented in the flossmanuals book, eg.
 [Animations](https://fr.flossmanuals.net/creating-point-and-click-games-with-escoria/animations/)
 and [Main Player](https://fr.flossmanuals.net/creating-point-and-click-games-with-escoria/main-player/) for most of your needs.
 
+The big difference is that your default animation player must be named `default` now.
+
 ## Static items
 
 For static items, ones that don't move, you still need to use the `AnimationPlayer`


### PR DESCRIPTION
I succumbed to the death of #197 by duplicating and re-creating a ton of animations in favor of the existing API.

The amount of animations and tracks is closing in on bullshit, even though I was able to reuse some things by copying nodes and editing them.

Be that as it may, this should be merged instead of #197 because it retains the existing way, but also makes the code a bit clearer and suppresses a useless error from `get_node(costume)` when the costume doesn't exist.
