### PR TITLE
Discourage background having child nodes

### DIFF
--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -171,9 +171,12 @@ func clicked(obj, pos, input_event = null):
 
 	# If a background is covered by an item, the item "wins"
 	if obj is esc_type.BACKGROUND:
-		for area in obj.get_child(0).get_overlapping_areas():
-			if area.has_method("is_clicked") and area.is_clicked():
-				return
+		var overlay = obj.get_child(0)  # Created by background.gd to intercept clicks
+		# Eg. Polygon2D does not have this method
+		if overlay.has_method("get_overlapping_areas"):
+			for area in overlay.get_overlapping_areas():
+				if area.has_method("is_clicked") and area.is_clicked():
+					return
 
 	# Hide the action menu (where available) when performing actions, so it's not eg. open while walking
 	if action_menu:

--- a/docs/background.md
+++ b/docs/background.md
@@ -6,6 +6,8 @@ To add a background to your scene, add a `Sprite` node as the first child of the
 
 This enables you to use `Area2D` nodes for your items, which lets you draw one or more `CollisionPolygon2D` child nodes to capture input, using only editor tools for the drawing. You can also add `Sprite` nodes as children of the `Area2D` item node if your items are not part of the background image.
 
+*Important note:* Having children on the background is possible, but discouraged. Usually there is a way of having them parallel to the background in the node tree, and not much testing has been put into children of the background. Please open an issue on GitHub if you find an insurmountable problem!
+
 ### Parallax
 
 To create an illusion of perspective in a 2D game, a technique called parallax scrolling effect can be used. This effect is achieved by adding one or more additional background layers, which are moved at a different speed than the foreground when the camera pans.


### PR DESCRIPTION
This should replace #213 as it doesn't try too hard to fix problems that are not relevant right now, but does add a note for the documentation.

I couldn't find a good place to add a documentation note about overlapping Area2Ds not working, too tired also to think, but I think a new GH issue is fine to document that until someone comes along to solve it.

Good to go?