### PR TITLE
Implement dialog layer

### DIFF
--- a/device/demo/rooms/room2/room.esc
+++ b/device/demo/rooms/room2/room.esc
@@ -1,0 +1,4 @@
+:ready
+
+say player room2:"ROOM2 IS AMAZING!"
+

--- a/device/demo/rooms/room2/room.tscn
+++ b/device/demo/rooms/room2/room.tscn
@@ -18,13 +18,13 @@ vertices = PoolVector2Array( 1491.17, 617.027, 1491.17, 657.925, 1112.47, 689.27
 polygons = [ PoolIntArray( 0, 1, 2, 3, 4, 5 ), PoolIntArray( 6, 4, 3, 7 ), PoolIntArray( 5, 4, 8 ), PoolIntArray( 9, 5, 8, 10 ), PoolIntArray( 11, 9, 10 ), PoolIntArray( 6, 7, 12, 13, 11, 10 ) ]
 outlines = [ PoolVector2Array( 414.945, 555.219, 766.377, 567.042, 1204.89, 557.953, 1491.17, 617.027, 1491.17, 657.925, 1112.47, 689.271, 705.031, 687.462, 350.588, 673.829, 159.734, 646.564, 158.201, 587.028 ), PoolVector2Array( 621.927, 596.206, 619.837, 630.408, 848.029, 649.017, 847.74, 611.076 ) ]
 
-[node name="scene" type="Node2D"]
+[node name="scene" type="Node2D" index="0"]
 
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_lock_": true
 }
-events_path = ""
+events_path = "res://demo/rooms/room2/room.esc"
 
 [node name="background" type="Sprite" parent="." index="0"]
 

--- a/device/demo/rooms/room2/zoom_in.esc
+++ b/device/demo/rooms/room2/zoom_in.esc
@@ -6,9 +6,12 @@ set_global zoom_level 3 [gt zoom_level 3]
 
 > [gt zoom_level 2]
  camera_set_zoom 0.25 1
+ say player zoom1:"WHOAH!"
  stop
 > [gt zoom_level 1]
  camera_set_zoom 0.5 1
+ say player zoom1:"whoah!"
  stop
 >
  camera_set_zoom 0.75 1
+ say player zoom1:"whoah"

--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -70,12 +70,13 @@ func finish():
 	_queue_free()
 
 func clamped_position(dialog_pos):
+	var vp_size = get_viewport().size
 	var my_size = $"anchor/text".get_size()
 	var center_offset = my_size.x / 2
 
-	var dist_from_right = vm.camera_limits.size.x - (dialog_pos.x + center_offset)
+	var dist_from_right = vp_size.x - (dialog_pos.x + center_offset)
 	var dist_from_left = dialog_pos.x - center_offset
-	var dist_from_bottom = vm.camera_limits.size.y - (dialog_pos.y + my_size.y)
+	var dist_from_bottom = vp_size.y - (dialog_pos.y + my_size.y)
 	var dist_from_top = dialog_pos.y - my_size.y
 
 	if dist_from_right < 0:
@@ -119,12 +120,14 @@ func init(p_params, p_context, p_intro, p_outro):
 	play_outro = p_outro
 	total_time = text.length() / characters_per_second
 	if !fixed_pos:
-		var pos
+		var dialog_pos
 		if character.has_node("dialog_pos"):
-			pos = character.get_node("dialog_pos").get_global_position()
+			dialog_pos = character.get_node("dialog_pos")
 		else:
-			pos = character.get_position()
+			dialog_pos = character
 
+		var pos = dialog_pos.global_position
+		pos = vm.zoom_transform.xform(pos)
 		pos = clamped_position(pos)
 		set_position(pos)
 

--- a/device/globals/dialog_player.gd
+++ b/device/globals/dialog_player.gd
@@ -11,7 +11,9 @@ func say(params, callback):
 	type = type + ProjectSettings.get_setting("escoria/platform/dialog_type_suffix")
 	var inst = get_resource(type).instance()
 	var z = inst.get_z_index()
-	get_node("/root").get_child(0).add_child(inst)
+
+	$"/root/scene/game/dialog_layer".add_child(inst)
+
 	var intro = true
 	var outro = true
 	if type in types:

--- a/device/globals/game.tscn
+++ b/device/globals/game.tscn
@@ -8,9 +8,21 @@
 script = ExtResource( 1 )
 fallbacks_path = "res://demo/fallbacks.esc"
 inventory_enabled = true
+drag_margin_left = 0.2
+drag_margin_top = 0.2
+drag_margin_right = 0.2
+drag_margin_bottom = 0.2
 camera_limits = Rect2( 0, 0, 0, 0 )
 
-[node name="dialog_player" parent="." index="0" instance=ExtResource( 2 )]
+[node name="dialog_layer" type="CanvasLayer" parent="." index="0"]
+
+layer = 1
+offset = Vector2( 0, 0 )
+rotation = 0.0
+scale = Vector2( 1, 1 )
+transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+
+[node name="dialog_player" parent="dialog_layer" index="0" instance=ExtResource( 2 )]
 
 [node name="hud_layer" type="CanvasLayer" parent="." index="1"]
 
@@ -21,8 +33,6 @@ scale = Vector2( 1, 1 )
 transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
 [node name="hud" parent="hud_layer" index="0" instance_placeholder="res://ui/hud.tscn"]
-
-mouse_default_cursor_shape = 0
 
 [node name="wait_timer" type="Timer" parent="." index="2"]
 

--- a/device/globals/game_am.tscn
+++ b/device/globals/game_am.tscn
@@ -3,14 +3,26 @@
 [ext_resource path="res://globals/game.gd" type="Script" id=1]
 [ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=2]
 
-[node name="game" type="Node"]
+[node name="game" type="Node" index="0"]
 
 script = ExtResource( 1 )
 fallbacks_path = "res://demo/fallbacks.esc"
 inventory_enabled = true
+drag_margin_left = 0.2
+drag_margin_top = 0.2
+drag_margin_right = 0.2
+drag_margin_bottom = 0.2
 camera_limits = Rect2( 0, 0, 0, 0 )
 
-[node name="dialog_player" parent="." index="0" instance=ExtResource( 2 )]
+[node name="dialog_layer" type="CanvasLayer" parent="." index="0"]
+
+layer = 1
+offset = Vector2( 0, 0 )
+rotation = 0.0
+scale = Vector2( 1, 1 )
+transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+
+[node name="dialog_player" parent="dialog_layer" index="0" instance=ExtResource( 2 )]
 
 [node name="hud_layer" type="CanvasLayer" parent="." index="1"]
 
@@ -18,8 +30,11 @@ layer = 1
 offset = Vector2( 0, 0 )
 rotation = 0.0
 scale = Vector2( 1, 1 )
+transform = Transform2D( 1, 0, 0, 1, 0, 0 )
 
 [node name="hud" parent="hud_layer" index="0" instance_placeholder="res://ui/hud_minimal.tscn"]
+
+mouse_default_cursor_shape = 0
 
 [node name="wait_timer" type="Timer" parent="." index="2"]
 
@@ -43,6 +58,8 @@ drag_margin_h_enabled = true
 drag_margin_v_enabled = true
 smoothing_enabled = false
 smoothing_speed = 5.0
+offset_v = 0.0
+offset_h = 0.0
 drag_margin_left = 0.2
 drag_margin_top = 0.2
 drag_margin_right = 0.2

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -70,6 +70,9 @@ var zoom_time
 var zoom_target
 var zoom_step
 
+# This is needed to adjust dialog positions and such
+var zoom_transform
+
 func save_settings():
 	save_data.save_settings(settings, null)
 
@@ -168,8 +171,13 @@ func update_camera(time):
 		if zstep.length() > diff.length() || zoom_time == 0:
 			camera.zoom = zoom_target
 			zoom_target = null
+			zoom_transform = camera.get_canvas_transform()
 		else:
 			camera.zoom += zstep
+	# Even when not zooming, somehow the clamping of dialog, when the
+	# scene is not zoomed, goes awry without this :/
+	else:
+		zoom_transform = camera.get_canvas_transform()
 
 func set_cam_limits(limits):
 	camera_limits = limits
@@ -679,6 +687,7 @@ func save():
 
 func set_camera(p_cam):
 	camera = p_cam
+	zoom_transform = camera.get_canvas_transform()
 
 func clear():
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "game_cleared")
@@ -760,7 +769,6 @@ func get_hud_scene():
 	return hpath
 
 func _ready():
-
 	save_data = load(ProjectSettings.get_setting("escoria/application/save_data")).new()
 	save_data.start()
 
@@ -799,3 +807,4 @@ func _ready():
 	connect("global_changed", self, "check_achievement")
 
 	set_process(true)
+


### PR DESCRIPTION
This fixes at least three known issues:

  1) Dialog not being clamped to viewport
  1) Dialog not showing when telon is faded out
  1) Dialog size being affected by zoom, obviously

I updated the demo as well, but it still looks ugly. I believe someone should take a look at it separately, like put some time into making all the positionings and alignments and such ok.

At least the demo shows that dialog size is not affected by zoom anymore, and that's the important part.

No documentation updates are required because the `dialog_layer` is in the `game*tscn` files. You break them, your fault.