### PR TITLE
Hopefully final clamping fixes

### DIFF
--- a/device/globals/action_menu.gd
+++ b/device/globals/action_menu.gd
@@ -12,14 +12,19 @@ func action_pressed(action):
 func target_visibility_changed():
 	stop()
 
-func check_clamp(click_pos):
+func clamped_position(click_pos):
+	var width = float(ProjectSettings.get("display/window/size/width"))
+	var height = float(ProjectSettings.get("display/window/size/height"))
 	var my_size = get_size()
-	var vp_size = get_viewport().size
+	var center_offset = my_size / Vector2(2, 2)  # Half to the left, half up
 
-	var dist_from_right = vp_size.x - (click_pos.x + my_size.x)
-	var dist_from_left = click_pos.x - my_size.x
-	var dist_from_bottom = vp_size.y - (click_pos.y + my_size.y)
-	var dist_from_top = click_pos.y - my_size.y
+	# Set the action menu in the middle
+	click_pos -= center_offset
+
+	var dist_from_right = width - (click_pos.x + my_size.x)
+	var dist_from_left = click_pos.x
+	var dist_from_bottom = height - (click_pos.y + my_size.y)
+	var dist_from_top = click_pos.y
 
 	if dist_from_right < 0:
 		click_pos.x += dist_from_right
@@ -30,7 +35,7 @@ func check_clamp(click_pos):
 	if dist_from_top < 0:
 		click_pos.y -= dist_from_top
 
-	return click_pos - my_size / 2
+	return click_pos
 
 func start(p_target):
 	if target != p_target:

--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -70,13 +70,14 @@ func finish():
 	_queue_free()
 
 func clamped_position(dialog_pos):
-	var vp_size = get_viewport().size
+	var width = float(ProjectSettings.get("display/window/size/width"))
+	var height = float(ProjectSettings.get("display/window/size/height"))
 	var my_size = $"anchor/text".get_size()
 	var center_offset = my_size.x / 2
 
-	var dist_from_right = vp_size.x - (dialog_pos.x + center_offset)
+	var dist_from_right = width - (dialog_pos.x + center_offset)
 	var dist_from_left = dialog_pos.x - center_offset
-	var dist_from_bottom = vp_size.y - (dialog_pos.y + my_size.y)
+	var dist_from_bottom = height - (dialog_pos.y + my_size.y)
 	var dist_from_top = dialog_pos.y - my_size.y
 
 	if dist_from_right < 0:

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -35,23 +35,27 @@ func set_mode(p_mode):
 	mode = p_mode
 
 func tooltip_clamped_position(tt_pos):
-	var vp_size = get_viewport().size
+	var width = float(ProjectSettings.get("display/window/size/width"))
+	var height = float(ProjectSettings.get("display/window/size/height"))
 	var tt_size = tooltip.get_size()
-	tt_pos -= tt_size / Vector2(2, 1)
+	var center_offset = tt_size.x / 2
 
-	# var dist_from_right = vp_size.x - (tt_pos.x + tt_size.x)
-	# var dist_from_left = tt_pos.x - tt_size.x
-	var dist_from_bottom = vp_size.y - (tt_pos.y + tt_size.y)
-	var dist_from_top = tt_pos.y - tt_size.y
+	# We want to have the center of the tooltip above where the cursor is, compensate first
+	tt_pos.x -= center_offset  # Shift it half-way to the left
+	tt_pos.y -= tt_size.y  # Shift it one size up
+
+	var dist_from_right = width - (tt_pos.x + tt_size.x)  # Check if the right edge, not eg. center, is overflowing
+	var dist_from_left = tt_pos.x
+	var dist_from_bottom = height - (tt_pos.y + tt_size.y)
+	var dist_from_top = tt_pos.y
 
 	## XXX: Godot has serious issues with the width of the text, so tooltips need
-	## to be wide at a fixed size, which makes horizontal clamping impossible.
+	## to be wide at a fixed size, which makes clamping a bit weird.
 	## The code is left here in case someone fixes Godot.
-	# if dist_from_right < 0:
-		# tt_pos.x += dist_from_right
-	# if dist_from_left < 0:
-		# tt_pos.x -= dist_from_left
-
+	if dist_from_right < 0:
+		tt_pos.x += dist_from_right
+	if dist_from_left < 0:
+		tt_pos.x -= dist_from_left
 	if dist_from_bottom < 0:
 		tt_pos.y += dist_from_bottom
 	if dist_from_top < 0:

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -286,7 +286,7 @@ func spawn_action_menu(obj):
 		player.walk_stop(player.position)
 
 	var pos = get_viewport().get_mouse_position()
-	var am_pos = action_menu.check_clamp(pos)
+	var am_pos = action_menu.clamped_position(pos)
 	action_menu.set_position(am_pos)
 	action_menu.show()
 	action_menu.start(obj)


### PR DESCRIPTION
Another fast-track merge coming in!

I noticed that dialog wasn't clamped correctly when running the development version of Iron Sky: Cold War in full screen, 4k resolution, the room zoomed, and the game resolution as 1080. This would be the default way for the game, so it can't be broken.

I got upset at how broken everything is so I channeled that into really digging into the clamping code and found myself fixing all the problems!

This also renames the clamper function for the action menu as iirc @fleskesvor requested me to do if this code is ever touched again.

If you don't have a game to test this with, the next release of Iron Sky: A Lunar Adventure will demonstrate this very clearly. Currently the tooltip overflows off the right-hand side of the screen and the action menu opens way off. Not sure when I have time for that release, though...