### PR TITLE
Even more angle code

### DIFF
--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -658,6 +658,8 @@ func save():
 			var pos = objects[k].get_position()
 			ret.append("teleport_pos " + k + " " + str(int(pos.x)) + " " + str(int(pos.y)) + "\n")
 			if objects[k].last_deg != null:
+				if objects[k].last_deg < 0 or objects[k].last_deg > 360:
+					vm.report_errors("global_vm", ["Trying to save game with " + objects[k].name + " at invalid angle " + str(objects[k].last_deg)])
 				ret.append("set_angle " + k + " " + str(objects[k].last_deg) + "\n")
 
 	ret.append("\n")
@@ -668,7 +670,11 @@ func save():
 		var pos = player.get_global_position()
 		var angle = player.last_deg
 		ret.append("teleport_pos player " + str(pos.x) + " " + str(pos.y) + "\n")
-		ret.append("set_angle player " + str(angle) + "\n")
+		# Angle may be unset if saving occurs when entering another room
+		if angle:
+			if angle < 0 or angle > 360:
+				vm.report_errors("global_vm", ["Trying to save game with player at invalid angle " + str(angle)])
+			ret.append("set_angle player " + str(angle) + "\n")
 
 	if cam_target != null:
 		ret.append("\n")

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -73,6 +73,34 @@ var zoom_step
 # This is needed to adjust dialog positions and such
 var zoom_transform
 
+# Helpers to deal with player's and items' angles
+func _get_deg_from_rad(rad_angle):
+	# We need some special magic to rotate the node
+	var deg = rad2deg(rad_angle) + 180 + 45
+	if deg >= 360:
+		deg = deg - 360
+
+	return deg
+
+func _get_dir(angle, obj_name, animations):
+	var deg = _get_deg_from_rad(angle)
+	return _get_dir_deg(deg, obj_name, animations)
+
+func _get_dir_deg(deg, obj_name, animations):
+	var dir = -1
+	var i = 0
+	for ang in animations.dir_angles:
+		if deg <= ang:
+			dir = i
+			break
+		i+=2
+
+	# It's an error to have the animations misconfigured
+	if dir == -1:
+		vm.report_errors("obj_name", ["No direction found for " + str(deg)])
+	return dir
+
+
 func save_settings():
 	save_data.save_settings(settings, null)
 

--- a/device/globals/interactive.gd
+++ b/device/globals/interactive.gd
@@ -31,26 +31,6 @@ func set_light_on_map(p_light):
 	else:
 		modulate(Color(1, 1, 1, 1))
 
-func _get_dir(angle):
-	var deg = rad2deg(angle) + 180 + 45
-	if deg >= 360:
-		deg = deg - 360
-	return _get_dir_deg(deg)
-
-func _get_dir_deg(deg):
-	var dir = -1
-	var i = 0
-	for ang in animations.dir_angles:
-		if deg <= ang:
-			dir = i
-			break
-		i+=2
-
-	# It's an error to have the animations misconfigured
-	if dir == -1:
-		vm.report_errors("interactive", ["No direction found for " + str(deg)])
-	return dir
-
 func walk_stop(pos):
 	set_position(pos)
 	walk_path = []
@@ -120,8 +100,8 @@ func _process(time):
 		var angle = (old_pos.angle_to_point(pos)) * -1
 		set_position(pos)
 
-		last_deg = rad2deg(angle)
-		last_dir = _get_dir(angle)
+		last_deg = vm._get_deg_from_rad(angle)
+		last_dir = vm._get_dir_deg(last_deg, self.name, animations)
 
 		if animation:
 			if animation.get_current_animation() != animations.directions[last_dir]:
@@ -139,7 +119,7 @@ func turn_to(deg):
 	moved = true
 
 	last_deg = deg
-	last_dir = _get_dir_deg(deg)
+	last_dir = vm._get_dir_deg(deg, self.name, animations)
 
 	if animation:
 		if !animation.get_current_animation() or animation.get_current_animation() != animations.directions[last_dir]:
@@ -154,7 +134,7 @@ func set_angle(deg):
 	moved = true
 
 	last_deg = deg
-	last_dir = _get_dir_deg(deg)
+	last_dir = vm._get_dir_deg(deg, self.name, animations)
 
 	if animations and "idles" in animations:
 		pose_scale = animations.idles[last_dir + 1]

--- a/device/globals/interactive.gd
+++ b/device/globals/interactive.gd
@@ -121,8 +121,10 @@ func turn_to(deg):
 	last_deg = deg
 	last_dir = vm._get_dir_deg(deg, self.name, animations)
 
-	if animation:
+	if animation and animations and "directions" in animations:
 		if !animation.get_current_animation() or animation.get_current_animation() != animations.directions[last_dir]:
+			# XXX: This requires manually scripting a wait
+			# and setting the correct idle animation
 			animation.play(animations.directions[last_dir])
 		pose_scale = animations.directions[last_dir + 1]
 		_update_terrain()
@@ -136,7 +138,7 @@ func set_angle(deg):
 	last_deg = deg
 	last_dir = vm._get_dir_deg(deg, self.name, animations)
 
-	if animations and "idles" in animations:
+	if animation and animations and "idles" in animations:
 		pose_scale = animations.idles[last_dir + 1]
 		_update_terrain()
 

--- a/device/globals/interactive.gd
+++ b/device/globals/interactive.gd
@@ -131,7 +131,12 @@ func turn_to(deg):
 
 func set_angle(deg):
 	if deg < 0 or deg > 360:
-		vm.report_errors("interactive", ["Invalid degree to turn to " + str(deg)])
+		# Compensate for savegame files during a broken version of Escoria
+		if vm.loading_game:
+			vm.report_warnings("interactive", ["Reset invalid degree " + str(deg)])
+			deg = 0
+		else:
+			vm.report_errors("interactive", ["Invalid degree to turn to " + str(deg)])
 
 	moved = true
 

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -327,7 +327,12 @@ func turn_to(deg):
 
 func set_angle(deg):
 	if deg < 0 or deg > 360:
-		vm.report_errors("player", ["Invalid degree to turn to " + str(deg)])
+		# Compensate for savegame files during a broken version of Escoria
+		if vm.loading_game:
+			vm.report_warnings("player", ["Reset invalid degree " + str(deg)])
+			deg = 0
+		else:
+			vm.report_errors("player", ["Invalid degree to turn to " + str(deg)])
 
 	last_deg = deg
 	last_dir = vm._get_dir_deg(deg, self.name, animations)

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -157,7 +157,7 @@ func interact(p_params):
 		walk_to(pos)
 	else:
 		if animations.dir_angles.size() > 0 && p_params[0].interact_angle != -1:
-			last_dir = _get_dir_deg(p_params[0].interact_angle)
+			last_dir = vm._get_dir_deg(p_params[0].interact_angle, self.name, animations)
 			animation.play(animations.idles[last_dir])
 			pose_scale = animations.idles[last_dir + 1]
 			_update_terrain()
@@ -173,7 +173,7 @@ func walk_stop(pos):
 	set_process(false)
 	if params_queue != null:
 		if animations.dir_angles.size() > 0 && params_queue[0].interact_angle != -1:
-			last_dir = _get_dir_deg(params_queue[0].interact_angle)
+			last_dir = vm._get_dir_deg(params_queue[0].interact_angle, self.name, animations)
 			animation.play(animations.idles[last_dir])
 			pose_scale = animations.idles[last_dir + 1]
 			_update_terrain()
@@ -190,26 +190,6 @@ func walk_stop(pos):
 	if walk_context != null:
 		vm.finished(walk_context)
 		walk_context = null
-
-func _get_dir(angle):
-	var deg = rad2deg(angle) + 180 + 45
-	if deg >= 360:
-		deg = deg - 360
-	return _get_dir_deg(deg)
-
-func _get_dir_deg(deg):
-	var dir = -1
-	var i = 0
-	for ang in animations.dir_angles:
-		if deg <= ang:
-			dir = i
-			break
-		i+=2
-
-	# It's an error to have the animations misconfigured
-	if dir == -1:
-		vm.report_errors("player", ["No direction found for " + str(deg)])
-	return dir
 
 
 func _notification(what):
@@ -292,8 +272,8 @@ func _process(time):
 		var angle = (old_pos.angle_to_point(pos)) * -1
 		set_position(pos)
 
-		last_deg = rad2deg(angle)
-		last_dir = _get_dir(angle)
+		last_deg = vm._get_deg_from_rad(angle)
+		last_dir = vm._get_dir_deg(last_deg, self.name, animations)
 
 		if animation.get_current_animation() != animations.directions[last_dir]:
 			animation.play(animations.directions[last_dir])
@@ -306,7 +286,7 @@ func teleport(obj):
 	if animations.dir_angles.size() > 0:
 		if "interact_angle" in obj and obj.interact_angle != -1:
 			last_deg = obj.interact_angle
-			last_dir = _get_dir_deg(obj.interact_angle)
+			last_dir = vm._get_dir_deg(obj.interact_angle, self.name, animations)
 			animation.play(animations.idles[last_dir])
 			pose_scale = animations.idles[last_dir + 1]
 
@@ -338,7 +318,7 @@ func turn_to(deg):
 		vm.report_errors("player", ["Invalid degree to turn to " + str(deg)])
 
 	last_deg = deg
-	last_dir = _get_dir_deg(deg)
+	last_dir = vm._get_dir_deg(deg, self.name, animations)
 
 	if animation.get_current_animation() != animations.directions[last_dir]:
 		animation.play(animations.directions[last_dir])
@@ -350,7 +330,7 @@ func set_angle(deg):
 		vm.report_errors("player", ["Invalid degree to turn to " + str(deg)])
 
 	last_deg = deg
-	last_dir = _get_dir_deg(deg)
+	last_dir = vm._get_dir_deg(deg, self.name, animations)
 
 	pose_scale = animations.idles[last_dir+1]
 	_update_terrain()

--- a/device/globals/player.gd
+++ b/device/globals/player.gd
@@ -332,6 +332,10 @@ func set_angle(deg):
 	last_deg = deg
 	last_dir = vm._get_dir_deg(deg, self.name, animations)
 
+	# The player may have a state animation from before, which would be
+	# resumed, so we immediately force the correct idle animation
+	if animation.get_current_animation() != animations.idles[last_dir]:
+		animation.play(animations.idles[last_dir])
 	pose_scale = animations.idles[last_dir+1]
 	_update_terrain()
 


### PR DESCRIPTION
I accidentally found out that a save game could still contain negative degrees. This was due to getting the angle from `rad2deg()` without the special compensation used elsewhere.

That lead me to refactor the code for both interactives and the player into the VM.

I tested this extensively by:
  * printing a ton of angle data out when walking the player
  *  having an npc walk between whatever items were available
  *  hacking a save game file with a `set_angle` and `turn_to` call for every angle.

The angles defined for both the player and the NPC are as follows:

```
const dir_angles = [0, 45, 90, 135, 180, 225, 270, 315, 360]
```

I also added some robustness in case someone tries to load a savegame with a broken angle value.

On top of that I fixed some setting of states (interactive) or playing animations (player) to make the code behave better.