### PR TITLE
Split load/run game to enable setup event

### DIFF
--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -395,33 +395,48 @@ func run_event(p_event):
 	printt("run_event: ", p_event.ev_name, p_event.ev_flags)
 
 	running_event = p_event
-	main.set_input_catch(true)
+	if p_event.ev_name == "setup":
+		if "CUT_BLACK" in p_event.ev_flags:
+			main.telon.cut_to_black()
 
-	# Hide tooltip for even simple events. It's up to NO_TT to not react to
-	# mouse events making it visible between eg. `say` commands, but do not
-	# clear it because that would leave an empty tooltip after NO_TT.
-	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip_visible", false)
+		add_level(p_event, true)
+	else:
+		main.set_input_catch(true)
 
-	if "NO_TT" in p_event.ev_flags:
-		set_tooltip_visible(false)
+		# Hide tooltip for even simple events. It's up to NO_TT to not react to
+		# mouse events making it visible between eg. `say` commands, but do not
+		# clear it because that would leave an empty tooltip after NO_TT.
+		get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_tooltip_visible", false)
 
-	if "NO_HUD" in p_event.ev_flags:
-		set_hud_visible(false)
+		if "NO_TT" in p_event.ev_flags:
+			set_tooltip_visible(false)
 
-	add_level(p_event, true)
+		if "NO_HUD" in p_event.ev_flags:
+			set_hud_visible(false)
+
+		add_level(p_event, true)
 
 func sched_event(time, obj, event):
 	event_queue.push_back([time, obj, event])
 
 func event_done():
 	printt("event_done: ", running_event.ev_name, running_event.ev_flags)
-	if "NO_TT" in running_event.ev_flags:
-		set_tooltip_visible(true)
+	if running_event.ev_name == "setup":
+		if not "LEAVE_BLACK" in running_event.ev_flags or not "ready" in game:
+			main.telon.cut_to_scene()
 
-	if "NO_HUD" in running_event.ev_flags:
-		set_hud_visible(true)
+		running_event = null
 
-	running_event = null
+		if "ready" in game:
+			emit_signal("run_event", game["ready"])
+	else:
+		if "NO_TT" in running_event.ev_flags:
+			set_tooltip_visible(true)
+
+		if "NO_HUD" in running_event.ev_flags:
+			set_hud_visible(true)
+
+		running_event = null
 
 func get_global(name):
 	# If no value or looks like boolean, return boolean for backwards compatibility

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -657,6 +657,8 @@ func load_file(p_game):
 		return
 
 	game = compile(p_game)
+
+func run_game():
 	# `load` and `ready` are exclusive because you probably don't want to
 	# reset the game state when a scene becomes ready, and `ready` is
 	# redundant when `load`ing state anyway.

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -24,6 +24,8 @@ var game_size
 var compiler
 var level
 
+var game
+
 var res_cache
 
 var cam_target = null
@@ -654,7 +656,7 @@ func load_file(p_game):
 	if !f.file_exists(p_game):
 		return
 
-	var game = compile(p_game)
+	game = compile(p_game)
 	# `load` and `ready` are exclusive because you probably don't want to
 	# reset the game state when a scene becomes ready, and `ready` is
 	# redundant when `load`ing state anyway.
@@ -683,7 +685,7 @@ func game_str_loaded(p_data = null):
 	if p_data == null:
 		return
 
-	var game = compile_str(p_data)
+	game = compile_str(p_data)
 	clear()
 	loading_game = true
 	run_event(game["load"])

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -81,6 +81,12 @@ func set_current_scene(p_scene, events_path=null, run_events=true):
 	if events_path and run_events:
 		vm.load_file(events_path)
 
+		# setup will kick off `:ready` if available
+		if "setup" in vm.game:
+			vm.run_event(vm.game["setup"])
+		else:
+			vm.run_game()
+
 func wait_finished():
 	vm.finished(wait_level)
 

--- a/device/ui/main_menu.gd
+++ b/device/ui/main_menu.gd
@@ -27,6 +27,7 @@ func start_new_game(p_confirm):
 	if !p_confirm:
 		return
 	vm.load_file(ProjectSettings.get_setting("escoria/platform/game_start_script"))
+	vm.run_game()
 
 func continue_pressed():
 	button_clicked()

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -2,6 +2,26 @@ General
 -------
 
 - Events:
+
+  When a scene is loaded, it may have events. We will not cover `:load` as it is used only internally for save games, nor will we cover [:start](starting-a-game.md) here.
+
+  To initialize a room properly, you may want to use `:setup` like this:
+
+```
+:setup
+teleport player door1 [eq last_exit door1]
+teleport player door2 [eq last_exit door2]
+```
+
+  It covers the fact that your `player` can be set anywhere in the room and be visible for just a moment before the `teleport` happens.
+
+  It's not mandatory, nor mutually exclusive with `:setup` to have a `:ready` event.
+
+```
+:ready
+say player player_wants_out:"I want out! To live my life and to be free!" [want_out]
+```
+
   When the player interacts with an object in the game, the object receives an even. Each event executes a series of commands.
   Events start with the character ":" in the Events file. Example:
 
@@ -21,6 +41,8 @@ say player player_does_not_wanna:"I don't wanna."
    * `TK` stands for "telekinetic". It means the player won't walk over to the item to say the line.
    * `FAST` stands for "fast". It means the player will walk at the speed of `player_doubleclick_speed_multiplier` to execute the action.
    * `NO_TT` stands for "No tooltip". It hides the tooltip for the duration of the event. Useful when having multiple `say` commands in it.
+   * `CUT_BLACK` applies only to `:setup`. It makes the screen go black during the setup phase. You will probably see a quick black flash, so use it only if you prefer it over the standard cut.
+   * `LEAVE_BLACK` applies only to `:setup`. In case your `:ready` starts with `cut_scene telon fade_in`, you must apply this flag or you will see a flash of your new scene before going black again for the `fade_in`.
 
 - Groups
   Commands can be grouped using the character ">" to start a group, and incrementing the indentation of the commands that belong to the group. Example:


### PR DESCRIPTION
This adds the `:setup` event with requisite changes to the VM.

The idea is that active NPCs, or the player, can be teleported to their correct places before the loaded
scene is ever shown.

This removes the problem of having the player (or NPC) "flash" in the wrong place before appearing in the correct one.