### PR TITLE
Revert faster setup code

### DIFF
--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -423,8 +423,11 @@ func event_done(ev_name):
 	assert ev_name == running_event.ev_name
 	printt("event_done: ", running_event.ev_name, running_event.ev_flags)
 	if ev_name == "setup":
-		if not "LEAVE_BLACK" in running_event.ev_flags:
+		if not "LEAVE_BLACK" in running_event.ev_flags or not "ready" in game:
 			main.telon.cut_to_scene()
+
+		if "ready" in game:
+			emit_signal("run_event", game["ready"])
 	else:
 		if "NO_TT" in running_event.ev_flags:
 			set_tooltip_visible(true)

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -83,7 +83,8 @@ func set_current_scene(p_scene, run_events=true):
 
 		# setup will kick off `:ready` if available
 		if "setup" in vm.game:
-			vm.run_event(vm.game["setup"])
+			if vm.running_event.ev_name != "setup":
+				vm.run_event(vm.game["setup"])
 		else:
 			vm.run_game()
 

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -24,24 +24,6 @@ func clear_scene():
 func set_scene(p_scene, run_events=true):
 	assert p_scene
 
-	## Uncomment this as a starting point in case of trouble,
-	## but it occurs that yielding here will cause lag and apparently
-	## serves no real purpose
-	# Like `:open` from a door in the last room
-	# if vm.running_event:
-	# 	yield(vm, "event_done")
-
-	if "events_path" in p_scene and p_scene.events_path and run_events:
-		vm.load_file(p_scene.events_path)
-
-		# :setup is pretty much required in the code, but fortunately
-		# we can help out with cases where one isn't necessary otherwise
-		if not "setup" in vm.game:
-			var fake_setup = vm.compile_str(":setup\n")
-			vm.game["setup"] = fake_setup["setup"]
-
-		vm.run_event(vm.game["setup"])
-
 	if current != null:
 		clear_scene()
 
@@ -92,29 +74,17 @@ func menu_collapse():
 
 func set_current_scene(p_scene, run_events=true):
 	#print_stack()
-	# printt("set_current_scene: ", p_scene, run_events)
 	current = p_scene
 	get_node("/root").move_child(current, 0)
 
 	# Loading a save game must set the scene but not run events
 	if "events_path" in current and current.events_path and run_events:
-		if vm.game:
-			# Having a game with `:setup` means we must wait for it to finish
-			if "setup" in vm.game:
-				assert vm.running_event
-				assert vm.running_event.ev_name == "setup"
-				yield(vm, "event_done")
-		else:
-			vm.load_file(current.events_path)
-			# For a new game, we must run `:setup` if available
-			# and wait for it to finish
-			if "setup" in vm.game:
-				vm.run_event(vm.game["setup"])
-				yield(vm, "event_done")
+		vm.load_file(current.events_path)
 
-		# Because 1) changing a scene and 2) having a scene become ready
-		# both call `set_current_scene`, we don't want to duplicate thing
-		if not vm.running_event:
+		# setup will kick off `:ready` if available
+		if "setup" in vm.game:
+			vm.run_event(vm.game["setup"])
+		else:
 			vm.run_game()
 
 func wait_finished():


### PR DESCRIPTION
This is because we encountered a bizarre camera alignment
bug when trying to pull off something cool with positioning
and zooming.

There is no obvious reason why this is the code that breaks,
unless it's related to the camera operations not being blocking.

Room changes are still quite fast with `queue_resource`, which
is the proper way to do it. Fixing the thread deadlock bug in
it would probably be the smarter way than trying to figure this
out.

Restored the relevant parts of b246a5761bfa6c80180e58ffbbf4910b014dddfc,
as it was reverted only to make the sequence free from conflicts.

Revert "Fix `not LEAVE_BLACK` behavior for new code"
This reverts commit 4137c1b61e65320274f75632ec87e63c702f4a1c.

Revert "Fake a :setup for scenes without one to keep up the flow of events"
This reverts commit 2625a144c837661b8f3e67feb217c59cb20522b1.

Revert "Yielding on any event causes lag, don't do it"
This reverts commit 05d93233f2644c9ddc08c88548ca1303b83884eb.

Revert "Make it possible to have a scene without events_path"
This reverts commit b246a5761bfa6c80180e58ffbbf4910b014dddfc.

Revert "Kick off :setup before previous scene is cleared"
This reverts commit 9ffda4fd7b4a87e66c44beace4533f3946915449.