### PR TITLE
Implement ! as a way of ending dialog

### DIFF
--- a/device/globals/dialog_dialog.gd
+++ b/device/globals/dialog_dialog.gd
@@ -31,8 +31,6 @@ func timer_timeout():
 
 # called from global_vm.gd::dialog() function
 func start(params, p_context):
-	vm.set_hud_visible(false)
-
 	printt("dialog start with params ", params.size())
 	context = p_context
 	cmd = params[0]
@@ -123,7 +121,6 @@ func _on_mouse_exit(button):
 	button.get_node("label").add_color_override("font_color_shadow", mouse_exit_shadow_color)
 
 func stop():
-	vm.set_hud_visible(true)
 	hide()
 	while container.get_child_count() > 0:
 		var c = container.get_child(0)

--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -20,6 +20,7 @@ var commands = {
 	"set_tooltip_visible": { "min_args": 1, "types": [TYPE_BOOL]},
 	"say": { "min_args": 2 },
 	"?": { "alias": "dialog"},
+	"!": { "alias": "end_dialog", "min_args": 0 },
 	"cut_scene": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL, TYPE_BOOL, TYPE_BOOL] },
 	">": { "alias": "branch"},
 	"inventory_add": { "min_args": 1 },

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -322,10 +322,17 @@ func test(cmd):
 	return true
 
 func dialog(params, level):
+	set_hud_visible(false)
+
 	# Ensure tooltip is hidden. It may remain visible when the NPC finishes saying something
 	# and then `dialog` is called.
 	get_tree().call_group("hud", "set_tooltip_visible", false)
 	get_tree().call_group("dialog_dialog", "start", params, level)
+
+func end_dialog(params):
+	if not running_event or not "NO_HUD" in running_event.ev_flags:
+		vm.set_hud_visible(true)
+
 
 func instance_level(p_event, p_root):
 	var level = {

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -82,8 +82,13 @@ func say(params):
 
 func dialog(params):
 	current_context.waiting = true
+	current_context.in_dialog = true
 	vm.dialog(params, current_context)
 	return vm.state_yield
+
+func end_dialog(params):
+	current_context.in_dialog = false
+	vm.end_dialog(params)
 
 func cut_scene(params):
 	if !check_obj(params[0], "cut_scene"):

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -275,7 +275,7 @@ Items can also change state by playing animations from an `AnimationPlayer` name
 Dialogs
 -------
 
-To start a dialog, use the "?" character, with some parameters, followed by a list of dialog options. Each option starts with the "-" character, followed by a parameter with the text to display in the dialog interface. Inside the option, a group of commands is specified using indentation.
+To start a dialog, use the "?" character, with some parameters, followed by a list of dialog options. This hides the HUD. Each option starts with the "-" character, followed by a parameter with the text to display in the dialog interface. Inside the option, a group of commands is specified using indentation. Use "!" to signify the dialog is over and the HUD may be restored. The HUD will not be restored if the running event is flagged NO_HUD. Either way the Escoria virtual machine will know if the game is in a dialog context.
 
 Example:
 
@@ -300,13 +300,16 @@ Example:
 				>	[!player_has_money]
 					say map_vendor "You can't afford it"
 					say player "I'll be back"
+          !
 					stop
 
 			- "Nevermind"
 				say player "Nevermind"
+        !
 				stop
 	- "Nevermind"
 		say player "Nevermind"
+    !
 		stop
 repeat
 ```


### PR DESCRIPTION
The purpose of this is to have a clean way of hiding the HUD during
dialog. The VM gets `in_dialog` in its context and hides the HUD.

When the `!` (alias `end_dialog`) command is called, the context
is reset. The HUD is also restored unless the event flag `NO_HUD`
is set.
