### PR TITLE
Camera tween

### DIFF
--- a/device/globals/camera.gd
+++ b/device/globals/camera.gd
@@ -1,5 +1,7 @@
 extends Camera2D
 
+var default_limits = {}  # This does not change once set
+
 var speed = 0
 var target
 
@@ -9,6 +11,25 @@ var zoom_step
 
 # This is needed to adjust dialog positions and such, see dialog_instance.gd
 var zoom_transform
+
+func set_limits(kwargs=null):
+	if not kwargs:
+		kwargs = {
+			"limit_left": -10000,
+			"limit_right": 10000,
+			"limit_top": -10000,
+			"limit_bottom": 10000,
+			"set_default": false,
+		}
+		print_stack()
+
+	self.limit_left = kwargs["limit_left"]
+	self.limit_right = kwargs["limit_right"]
+	self.limit_top = kwargs["limit_top"]
+	self.limit_bottom = kwargs["limit_bottom"]
+
+	if "set_default" in kwargs and kwargs["set_default"] and not default_limits:
+		default_limits = kwargs
 
 func set_target(p_speed, p_target):
 	speed = p_speed

--- a/device/globals/camera.gd
+++ b/device/globals/camera.gd
@@ -85,6 +85,27 @@ func set_zoom(p_zoom_level, p_time):
 
 		tween.start()
 
+func push(p_target, p_time, p_type):
+	var time = float(p_time)
+	var type = "TRANS_" + p_type
+
+	if not p_target.has_node("camera_pos"):
+		vm.report_errors("camera", ["Tried pushing to target without camera_pos: " + p_target.global_id])
+
+	var camera_pos = p_target.get_node("camera_pos")
+
+	target = p_target
+
+	if tween.is_active():
+		tween.stop_all()
+
+	if camera_pos is Camera2D:
+		tween.interpolate_property(self, "zoom", self.zoom, camera_pos.zoom, time, Tween.get(type), Tween.EASE_IN_OUT)
+
+	tween.interpolate_property(self, "global_position", self.global_position, camera_pos.global_position, time, Tween.get(type), Tween.EASE_IN_OUT)
+
+	tween.start()
+
 func target_reached(obj, key):
 	tween.stop_all()
 

--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -52,6 +52,7 @@ var commands = {
 	"camera_set_pos": { "min_args": 3, "types": [TYPE_REAL, TYPE_INT, TYPE_INT] },
 	"camera_set_zoom": { "min_args": 1, "types": [TYPE_REAL] },
 	"camera_set_zoom_height": { "min_args": 1, "types": [TYPE_INT] },
+	"camera_push": { "min_args": 1, "types": [TYPE_STRING] },
 	"autosave": { "min_args": 0 },
 	"queue_resource": { "min_args": 1, "types": [TYPE_STRING, TYPE_BOOL] },
 	"queue_animation": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL] },

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -616,6 +616,7 @@ func set_inventory_enabled(p_enabled):
 		$"hud_layer/hud/inv_toggle".hide()
 
 func set_camera_limits():
+	var limits = {}
 	if camera_limits.size.x == 0 and camera_limits.size.y == 0:
 		var area = Rect2()
 		for child in get_parent().get_children():
@@ -629,19 +630,26 @@ func set_camera_limits():
 			printt("No limit area! Using viewport")
 			area.size = get_viewport().size
 
-		camera.limit_left = area.position.x
-		camera.limit_right = area.position.x + area.size.x
-		camera.limit_top = area.position.y
-		camera.limit_bottom = area.position.y + area.size.y
 
 		printt("setting camera limits from scene ", area)
+		limits = {
+			"limit_left": area.position.x,
+			"limit_right": area.position.x + area.size.x,
+			"limit_top": area.position.y,
+			"limit_bottom": area.position.y + area.size.y,
+			"set_default": true,
+		}
 	else:
-		camera.limit_left = camera_limits.position.x
-		camera.limit_right = camera_limits.position.x + camera_limits.size.x
-		camera.limit_top = camera_limits.position.y
-		camera.limit_bottom = camera_limits.position.y + camera_limits.size.y + main.screen_ofs.y * 2
+		limits = {
+			"limit_left": camera_limits.position.x,
+			"limit_right": camera_limits.position.x + camera_limits.size.x,
+			"limit_top": camera_limits.position.y,
+			"limit_bottom": camera_limits.position.y + camera_limits.size.y + main.screen_ofs.y * 2,
+			"set_default": true,
+		}
 		printt("setting camera limits from parameter ", camera_limits)
 
+	camera.set_limits(limits)
 	camera.set_offset(main.screen_ofs * 2)
 
 	#vm.update_camera(0.000000001)

--- a/device/globals/game.tscn
+++ b/device/globals/game.tscn
@@ -68,4 +68,13 @@ editor_draw_limits = false
 editor_draw_drag_margin = false
 script = ExtResource( 3 )
 
+[node name="tween" type="Tween" parent="camera" index="0"]
+
+repeat = false
+playback_process_mode = 1
+playback_speed = 1.0
+playback/active = false
+playback/repeat = false
+playback/speed = 1.0
+
 

--- a/device/globals/game_am.tscn
+++ b/device/globals/game_am.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://ui/dialog_player.tscn" type="PackedScene" id=2]
 [ext_resource path="res://globals/camera.gd" type="Script" id=3]
 
-[node name="game" type="Node"]
+[node name="game" type="Node" index="0"]
 
 script = ExtResource( 1 )
 fallbacks_path = "res://demo/fallbacks.esc"
@@ -69,5 +69,14 @@ editor_draw_screen = true
 editor_draw_limits = false
 editor_draw_drag_margin = false
 script = ExtResource( 3 )
+
+[node name="tween" type="Tween" parent="camera" index="0"]
+
+repeat = false
+playback_process_mode = 1
+playback_speed = 1.0
+playback/active = false
+playback/repeat = false
+playback/speed = 1.0
 
 

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -179,6 +179,13 @@ func camera_set_target(p_speed, p_target):
 func camera_set_zoom(p_zoom_level, p_time):
 	camera.set_zoom(p_zoom_level, p_time)
 
+func camera_push(p_target, p_time, p_type):
+	var target = get_object(p_target)
+
+	camera.push(target, p_time, p_type)
+
+	cam_target = p_target
+
 func inventory_has(p_obj):
 	return get_global("i/"+p_obj)
 

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -639,8 +639,6 @@ func _process(time):
 	check_event_queue(time)
 	run()
 	check_autosave()
-	if camera:
-		camera.update(time)
 
 func run_top():
 	var top = stack[stack.size()-1]

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -30,7 +30,6 @@ var game
 var res_cache
 
 var cam_target = null
-var cam_speed = 0
 var camera
 
 ## One game, one VM; there are many things we can have only one of, track them here.
@@ -172,7 +171,6 @@ func camera_set_target(p_speed, p_target):
 			target[i] = obj
 
 	# Set state for savegames
-	cam_speed = p_speed
 	cam_target = p_target
 
 	# Kick it
@@ -716,7 +714,6 @@ func change_scene(params, context, run_events=true):
 	if context != null:
 		context.waiting = false
 
-	cam_speed = 0
 	cam_target = null
 	autosave_pending = true
 
@@ -893,7 +890,6 @@ func save():
 	ret.append("## Camera\n\n")
 	if cam_target != null:
 		if typeof(cam_target) == TYPE_VECTOR2:
-			#ret.append("camera_set_pos " + str(cam_speed) + " " + str(int(cam_target.x)) + " " + str(int(cam_target.y)) + "\n")
 			ret.append("camera_set_pos 0 " + str(int(cam_target.x)) + " " + str(int(cam_target.y)) + "\n")
 		else:
 			var tlist = ""
@@ -907,7 +903,6 @@ func save():
 				tlist = tlist + " player"
 
 			ret.append("camera_set_target 0" + tlist + "\n")
-			ret.append("camera_set_target " + str(cam_speed) + tlist + "\n")
 
 	if customs:
 		ret.append("\n")

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -298,6 +298,13 @@ func camera_set_zoom_height(params):
 	var time = params[1] if params.size() > 1 else 0
 	vm.camera_set_zoom(magnitude, float(time))
 
+func camera_push(params):
+	var target = params[0]
+	var time = params[1] if params.size() > 1 else 1
+	var type = params[2] if params.size() > 2 else "QUAD"
+
+	vm.camera_push(target, time, type)
+
 func set_globals(params):
 	var pat = params[0]
 	var val = params[1]

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -284,6 +284,10 @@ Items can also change state by playing animations from an `AnimationPlayer` name
 -`camera_set_zoom_height pixels [time]`
   Similar to the command above, but uses pixel height instead of magnitude to zoom.
 
+-`camera_push target [time] [type]`
+  Push camera to target. Target must have `camera_pos` set. If it's of type `Camera2D`, its zoom will be used as well as position.
+  `type` is any of the `Tween.TransitionType` values without the prefix, eg. `LINEAR`, `QUART` or `CIRC`; defaults to `QUART`.
+
 - `queue_resource path front_of_queue`
   Queues the load of a resource in a background thread. The path must be a full path inside your game, for example "res://scenes/next_scene.tscn". The "front_of_queue" parameter is optional (default value false), to put the resource in the front of the queue. Queued resources are cleared when a change scene happens (but after the scene is loaded, meaning you can queue resources that belong to the next scene).
 


### PR DESCRIPTION
Based on some discussion with @StraToN, some example code of his (merci!), and a Youtube video I don't have the link for, it makes sense to use `Tween` nodes instead of the calculated-step-based camera movement/zoom.

This PR reimplements the backend.
