### PR TITLE
Tooltip unification

### DIFF
--- a/device/globals/esc_compile.gd
+++ b/device/globals/esc_compile.gd
@@ -18,7 +18,6 @@ var commands = {
 	"play_snd": { "min_args": 2, "types": [TYPE_STRING, TYPE_STRING, TYPE_BOOL] },
 	"set_state": { "min_args": 2 },
 	"set_hud_visible": { "min_args": 1, "types": [TYPE_BOOL]},
-	"set_tooltip_visible": { "min_args": 1, "types": [TYPE_BOOL]},
 	"say": { "min_args": 2 },
 	"?": { "alias": "dialog"},
 	"!": { "alias": "end_dialog", "min_args": 0 },

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -72,9 +72,6 @@ func ev_left_click_on_bg(obj, pos, event):
 		click_anim.play("click")
 
 	player.walk_to(pos, walk_context)
-	# Leave the tooltip if the player is in eg. a "use key with" state
-	if not vm.current_action and vm.hover_object:
-		vm.hover_end()
 
 	if vm.tooltip:
 		if not vm.current_tool:
@@ -206,11 +203,6 @@ func ev_left_click_on_inventory_item(obj, pos, event):
 	# Use and look are the only valid choices with an action menu
 	if vm.action_menu:
 		vm.set_current_action("use")
-		# XXX: Setting an action here does not update the tooltip like `mouse_enter` does. Compensate.
-		if vm.tooltip:
-			var text = tr("use.id")
-			text = text.replace("%1", tr(obj.get_tooltip()))
-			vm.tooltip.set_tooltip(text)
 
 	if vm.current_action == "use" and obj.use_combine:
 		if not vm.current_tool:
@@ -218,20 +210,26 @@ func ev_left_click_on_inventory_item(obj, pos, event):
 		elif vm.current_tool != obj:
 			interact([obj, vm.current_action, vm.current_tool])
 
+	if vm.tooltip:
+		vm.tooltip.update()
+
 func ev_right_click_on_inventory_item(obj, pos, event):
 	printt(obj.name, "right-clicked at", pos, "with", event, can_click())
 
 	if not can_click():
 		return
 
-	# Do not set `look` as permanent action
-	interact([obj, "look"])
-	# XXX: Moving the mouse during `:look` will cause the tooltip to disappear
-	# so the following is a good-enough-for-now fix for it
-	if vm.tooltip:
-		vm.tooltip.set_tooltip(obj.get_tooltip())
-
-	vm.hover_begin(obj)
+	if vm.current_tool:
+		vm.clear_current_tool()
+		if vm.tooltip:
+			vm.tooltip.update()
+	else:
+		# Do not set `look` as permanent action
+		interact([obj, "look"])
+		# XXX: Moving the mouse during `:look` will cause the tooltip to disappear
+		# so the following is a good-enough-for-now fix for it
+		if vm.tooltip:
+			vm.tooltip.update()
 
 func ev_mouse_enter_item(obj):
 	if obj.inventory:
@@ -247,7 +245,6 @@ func ev_mouse_enter_item(obj):
 		yield(vm.overlapped_obj, "mouse_exit_item")
 
 	vm.set_overlapped_obj(obj)
-	vm.hover_begin(obj)
 
 	# Immediately bail out if the action menu is open
 	if vm.action_menu and vm.action_menu.is_visible():
@@ -261,7 +258,6 @@ func ev_mouse_enter_item(obj):
 
 	if vm.tooltip:
 		var tt = obj.get_tooltip()
-		var text
 
 		# XXX: The warning report may be removed if it turns out to be too annoying in practice
 		if not tt:
@@ -272,23 +268,7 @@ func ev_mouse_enter_item(obj):
 			# `mouse_enter` events have no guaranteed order.
 			return
 
-		# {{{ tooltip handling
-		if vm.current_action and vm.current_tool:
-			text = tr(vm.current_action + ".combine_id")
-			text = text.replace("%2", tr(tt))
-			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
-		else:
-			text = tr(tt)
-		# }}}
-
-		# When following the mouse, prevent text from flashing for a moment in the wrong place
-		if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
-			var pos = get_viewport().get_mouse_position()
-
-			vm.tooltip.set_position(pos)
-
-		vm.tooltip.set_tooltip(text)
-		vm.tooltip.show()
+	vm.hover_begin(obj)
 
 func ev_mouse_enter_inventory_item(obj):
 	if not inventory:
@@ -298,11 +278,8 @@ func ev_mouse_enter_inventory_item(obj):
 
 	printt(obj.name, "mouse_enter_inventory_item")
 
-	vm.hover_begin(obj)
-
 	if vm.tooltip:
 		var tt = obj.get_tooltip()
-		var text
 
 		# XXX: The warning report may be removed if it turns out to be too annoying in practice
 		if not tt:
@@ -313,52 +290,21 @@ func ev_mouse_enter_inventory_item(obj):
 			# `mouse_enter` events have no guaranteed order.
 			return
 
-		# {{{ tooltip handling
-		if not vm.current_action:
-			text = tr(tt)
-		else:
-			var action = inventory.get_action()
-			if action == "":
-				action = vm.current_action
-
-			if vm.current_tool and vm.current_tool != obj:
-				text = tr(vm.current_action + ".combine_id")
-				text = text.replace("%2", tr(tt))
-				text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
-			elif vm.current_tool:
-				text = tr(action + ".id")
-				text = text.replace("%1", tr(tt))
-		# }}}
-
-		# When following the mouse, prevent text from flashing for a moment in the wrong place
-		if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
-			var pos = get_viewport().get_mouse_position()
-
-			vm.tooltip.set_position(pos)
-
-		vm.tooltip.set_tooltip(text)
-		vm.tooltip.show()
+	vm.hover_begin(obj)
 
 func ev_mouse_exit_item(obj):
 	printt(obj.name, "mouse_exit_item")
 
-	if vm.tooltip:
-		var text = ""
-
-		if vm.current_action and vm.current_tool:
-			text = tr(vm.current_action + ".id")
-			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
-
-			vm.tooltip.set_tooltip(text)
-			vm.tooltip.show()
-		else:
-			vm.tooltip.hide()
-
-	# Want to retain the hover if the player is about to perform an action
-	if not vm.current_action and vm.hover_object:
-		vm.hover_end()
-
 	vm.clear_overlapped_obj()
+
+	if vm.action_menu and vm.action_menu.is_visible():
+		return
+
+	# Also bail out if inventory blocks us
+	if inventory and inventory.blocks_tooltip():
+		return
+
+	vm.hover_end()
 
 func ev_mouse_exit_inventory_item(obj):
 	printt(obj.name, "mouse_exit_inventory_item")
@@ -371,21 +317,7 @@ func ev_mouse_exit_inventory_item(obj):
 			vm.report_errors("game", ["Tooltip visible while action menu is visible"])
 		return
 
-	if vm.tooltip:
-		var text = ""
-
-		if vm.current_action and vm.current_tool:
-			text = tr(vm.current_action + ".id")
-			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
-
-			vm.tooltip.set_tooltip(text)
-			vm.tooltip.show()
-		else:
-			vm.tooltip.hide()
-
-	# Want to retain the hover if the player is about to perform an action
-	if not vm.current_action and vm.hover_object:
-		vm.hover_end()
+	vm.hover_end()
 
 func ev_mouse_enter_trigger(obj):
 	printt(obj.name, "mouse_enter_trigger")
@@ -401,11 +333,9 @@ func ev_mouse_enter_trigger(obj):
 		return
 
 	vm.set_overlapped_obj(obj)
-	vm.hover_begin(obj)
 
 	if vm.tooltip:
 		var tt = obj.get_tooltip()
-		var text
 
 		# XXX: The warning report may be removed if it turns out to be too annoying in practice
 		if not tt:
@@ -416,33 +346,15 @@ func ev_mouse_enter_trigger(obj):
 			# `mouse_enter` events have no guaranteed order.
 			return
 
-		text = tr(tt)
-
-		# When following the mouse, prevent text from flashing for a moment in the wrong place
-		if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
-			var pos = get_viewport().get_mouse_position()
-
-			vm.tooltip.set_position(pos)
-
-		vm.tooltip.set_tooltip(text)
-		vm.tooltip.show()
+	vm.hover_begin(obj)
 
 func ev_mouse_exit_trigger(obj):
 	printt(obj.name, "mouse_exit_trigger")
 
-	if vm.tooltip:
-		var text = ""
-
-		if vm.current_action and vm.current_tool:
-			text = tr(vm.current_action + ".id")
-			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
-
-			vm.tooltip.set_tooltip(text)
-			vm.tooltip.show()
-		else:
-			vm.tooltip.hide()
-
 	vm.clear_overlapped_obj()
+	# FIXME: Action menu on item, click trigger which causes dialog, hover_object is not set, but should be
+	if vm.hover_object:
+		vm.hover_end()
 
 func spawn_action_menu(obj):
 	if vm.action_menu == null:

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -600,12 +600,6 @@ func _process(time):
 
 	player.walk_to(player.get_position() + dir * 20)
 
-func _input(ev):
-	if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
-		# Must verify `position` is there, key inputs do not have it
-		if vm.hover_object and "position" in ev:
-			vm.tooltip.set_position(ev.position)
-
 func set_inventory_enabled(p_enabled):
 	inventory_enabled = p_enabled
 	if !has_node("hud_layer/hud/inv_toggle"):

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -136,6 +136,8 @@ func hover_begin(obj):
 		report_errors("global_vm", ["Trying to hover " + obj.global_id + " which is not ITEM or TRIGGER"])
 
 	hover_object = obj
+	if tooltip:
+		tooltip.update()
 
 func hover_end():
 	if not hover_object:
@@ -147,6 +149,8 @@ func hover_end():
 		hover_object.clicked = false
 
 	hover_object = null
+	if tooltip:
+		tooltip.update()
 
 func camera_set_target(p_speed, p_target):
 	if not camera:
@@ -454,10 +458,9 @@ func event_done(ev_name):
 	running_event = null
 
 	# For example dialog will hide the tooltip, but we may want to see it again
-	if tooltip and self.hover_object:
+	if tooltip:
 		if not action_menu or not action_menu.is_visible():
-			tooltip.set_tooltip(self.hover_object.get_tooltip())
-			tooltip.show()
+			tooltip.update()
 
 func get_global(name):
 	# If no value or looks like boolean, return boolean for backwards compatibility

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -203,14 +203,6 @@ func say(params, level):
 func set_hud_visible(p_visible):
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_visible", p_visible)
 
-func set_tooltip_visible(p_visible):
-	# Wrapper that vm_level can use
-	if tooltip:
-		if p_visible:
-			tooltip.show()
-		else:
-			tooltip.hide()
-
 func dialog_config(params):
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "dialog", "config", params)
 

--- a/device/globals/inventory.gd
+++ b/device/globals/inventory.gd
@@ -25,13 +25,11 @@ func open():
 		return
 
 	if vm.tooltip:
-		# Hide if we don't have a tool
-		if not vm.current_tool:
-			vm.tooltip.hide()
-		# And this is where it gets fishy ...
-		else:
-			# ... because we must re-enter the item to get the tooltip sorted
-			vm.current_tool.emit_signal("mouse_enter_inventory_item", vm.current_tool)
+		# Anything left underneath the inventory is not considered hovering
+		if vm.hover_object:
+			vm.hover_end()
+
+		vm.tooltip.update()
 
 	if vm.action_menu:
 		# `false` is for show_tooltip=false

--- a/device/globals/tooltip.gd
+++ b/device/globals/tooltip.gd
@@ -85,6 +85,12 @@ func _clamp(tt_pos):
 func set_position(pos):
 	.set_position(_clamp(pos))
 
+func _input(ev):
+	if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse"):
+		# Must verify `position` is there, key inputs do not have it
+		if "position" in ev:
+			self.set_position(ev.position)
+
 func _ready():
 	vm.register_tooltip(self)
 	orig_size = self.rect_size

--- a/device/globals/tooltip.gd
+++ b/device/globals/tooltip.gd
@@ -27,6 +27,34 @@ func hide():
 
 	set_tooltip_visible(false)
 
+func update():
+	var text = ""
+
+	if vm.hover_object:
+		var tt = vm.hover_object.get_tooltip()
+
+		if vm.current_action and vm.current_tool and vm.current_tool != vm.hover_object:
+			text = tr(vm.current_action + ".combine_id")
+			text = text.replace("%2", tr(tt))
+			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
+		elif vm.current_action == "use" and vm.current_tool:
+			text = tr("use.id")
+			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
+		else:
+			text = tr(tt)
+	else:
+		if vm.current_action and vm.current_tool:
+			if not vm.hover_object:
+				text = tr(vm.current_action + ".id")
+				text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
+
+	vm.tooltip.set_tooltip(text)
+	if text:
+		vm.tooltip.show()
+		self.set_position(get_global_mouse_position())
+	else:
+		vm.tooltip.hide()
+
 func set_tooltip(text):
 	if not typeof(text) == TYPE_STRING:
 		vm.report_errors("tooltip", ["Trying to set tooltip of type: " + str(typeof(text))])

--- a/device/globals/trigger.gd
+++ b/device/globals/trigger.gd
@@ -46,6 +46,9 @@ func input(event):
 	if inventory and inventory.blocks_tooltip():
 		return
 
+	if vm.action_menu and vm.action_menu.is_visible():
+		vm.action_menu.stop()
+
 	var player = vm.get_object("player")
 	# Get mouse position, since event.position only works with Area2D exits
 	var pos = get_global_mouse_position()

--- a/device/globals/vm_level.gd
+++ b/device/globals/vm_level.gd
@@ -98,9 +98,6 @@ func set_state(params):
 func set_hud_visible(params):
 	vm.set_hud_visible(params[0])
 
-func set_tooltip_visible(params):
-	vm.set_tooltip_visible(params[0])
-
 func say(params):
 	if !check_obj(params[0], "say"):
 		return vm.state_return

--- a/docs/esc_reference.md
+++ b/docs/esc_reference.md
@@ -191,9 +191,6 @@ Items can also change state by playing animations from an `AnimationPlayer` name
 - `set_hud_visible visible`
   If you have a cut-scene-like sequence where the player doesn't have control, and you also have HUD elements visible, use this to hide the HUD. You want to do that because it explicitly signals the player that there is no control over the game at the moment. "visible" is true or false.
 
-- `set_tooltip_visible visible`
-  Escoria's dialog system, like the `say` command, has no feedback channel to the tooltip system. This means the tooltip will appear between lines of dialog, which is confusing. Unless someone solves this problem, you should consider hiding the tooltip (or the entire hud) when many lines are spoken.
-
 - `say object text [type] [avatar]`
   Runs the specified string as a dialog said by the object. Blocks execution until the dialog finishes playing. Optional parameters:
   - "type" determines the type of dialog UI to use. Default value is "default"


### PR DESCRIPTION
The tooltip has turned out to be one of our most problematic components.

Moving to the signal-based architecture (though `trigger.gd` isn't quite there yet), there was a lot of duplication wrt the tooltip. It also occurred that `hover_object` was crazy overloaded and probably contributed to our problems.

What happens now is that the tooltip handles its own input and implements the `.update()` method for setting text based on the `global_vm` state, and thus also its visibility.

This simplified the signal handlers greatly, because now they can call `vm.hover_begin(obj)` and `vm.hover_end()` to set the state and those functions update the tooltip.

I decided to couple tooltip updating tightly, instead of having the signal handlers first set the state and then update the tooltip, because loose coupling leads to mistakes easier. This may be refactored later if eg. touch interfaces require something special.

There is a workaround for the trigger, which I don't like. Opening the action menu on an item, walking to a `trigger` which causes dialog, and then moving the player onto the regular `background` causes a bug. Somehow there is no `vm.hover_object`, though entering the `trigger` should have set it.

This may or may not be a Godot-level problem. It seems the `exit` signals are somehow deferred and I haven't really been able to `yield()` on them. My current hypothesis is that we should `yield()` on some Godot-internal or `CanvasLayer`-level or whatever signal, but I have no idea what that might be. Does anyone know?

@StraToN avez-vous des comments en le design ou l'implementaion mes codes?