### PR TITLE
Hover stack

### DIFF
--- a/device/globals/action_menu.gd
+++ b/device/globals/action_menu.gd
@@ -56,8 +56,8 @@ func stop(show_tooltip=true):
 	target = null
 	hide()
 	if ProjectSettings.get_setting("escoria/ui/tooltip_follows_mouse") and show_tooltip:
-		# If there's an `overlapped_obj`, let it handle the tooltip part
-		vm.reset_overlapped_obj()
+		if vm.tooltip:
+			vm.tooltip.update()
 
 func set_position(pos):
 	.set_position(_clamp(pos))

--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -86,10 +86,6 @@ func finish():
 
 	_queue_free()
 
-	# BUG: moving cursor during speech will show the wrong object
-	# after speech, until the mouse is moved.
-	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "reset_overlapped_obj")
-
 func _clamp(dialog_pos):
 	var width = float(ProjectSettings.get("display/window/size/width"))
 	var height = float(ProjectSettings.get("display/window/size/height"))

--- a/device/globals/dialog_player.gd
+++ b/device/globals/dialog_player.gd
@@ -3,11 +3,6 @@ extends ResourcePreloader
 var types = {}
 
 func say(params, callback):
-	# Check if we have an inventory, because it might affect dialog positioning
-	var inventory
-	if $"/root/scene/game/hud_layer/hud".has_node("inventory"):
-		inventory = $"/root/scene/game/hud_layer/hud/inventory"
-
 	var type
 	if params.size() < 3 || !has_resource(params[2]):
 		type = "default"
@@ -18,14 +13,15 @@ func say(params, callback):
 	var zoom_diff = abs(vm.camera.zoom.x - $"/root/scene".default_zoom)
 	var need_zoomed = round(zoom_diff) > 0
 
-	if (inventory and inventory.blocks_tooltip()) or need_zoomed:
+	# Check if we have an inventory, because it might affect dialog positioning
+	if (vm.inventory and vm.inventory.blocks_tooltip()) or need_zoomed:
 		type = "bottom"
 
 	type = type + ProjectSettings.get_setting("escoria/platform/dialog_type_suffix")
 	var inst = get_resource(type).instance()
 	var z = inst.get_z_index()
 
-	if (inventory and inventory.blocks_tooltip()) or need_zoomed:
+	if (vm.inventory and vm.inventory.blocks_tooltip()) or need_zoomed:
 		inst.fixed_pos = true
 
 	$"/root/scene/game/dialog_layer".add_child(inst)

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -246,16 +246,6 @@ func ev_mouse_enter_item(obj):
 
 	vm.hover_push(obj)
 
-	# Immediately bail out if the action menu is open
-	if vm.action_menu and vm.action_menu.is_visible():
-		if vm.tooltip and vm.tooltip.visible:
-			vm.report_errors("game", ["Tooltip visible while action menu is visible"])
-		return
-
-	# Also bail out if inventory blocks us
-	if inventory and inventory.blocks_tooltip():
-		return
-
 	if vm.tooltip:
 		var tt = obj.get_tooltip()
 
@@ -267,6 +257,10 @@ func ev_mouse_enter_item(obj):
 			# the tooltip may be emptied by the light not having a tooltip. This is because the
 			# `mouse_enter` events have no guaranteed order.
 			return
+
+	# Bail out if inventory blocks us
+	if inventory and inventory.blocks_tooltip():
+		return
 
 func ev_mouse_enter_inventory_item(obj):
 	if not inventory:
@@ -293,14 +287,11 @@ func ev_mouse_enter_inventory_item(obj):
 func ev_mouse_exit_item(obj):
 	printt(obj.name, "mouse_exit_item")
 
-	if vm.action_menu and vm.action_menu.is_visible():
-		return
+	vm.hover_pop(obj)
 
 	# Also bail out if inventory blocks us
 	if inventory and inventory.blocks_tooltip():
 		return
-
-	vm.hover_pop(obj)
 
 func ev_mouse_exit_inventory_item(obj):
 	printt(obj.name, "mouse_exit_inventory_item")

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -244,15 +244,6 @@ func ev_mouse_enter_item(obj):
 
 	printt(obj.name, "mouse_enter_item")
 
-	## XXX: Would want a design where this is not relevant!
-	if vm.overlapped_obj and vm.overlapped_obj != obj:
-		# Be sure we have exited the other object, because
-		# sometimes item2's `mouse_entered` happens before
-		# item1's `mouse_exited`. This causes the tooltip to disappear!
-		yield(vm.overlapped_obj, "mouse_exit_item")
-
-	vm.set_overlapped_obj(obj)
-
 	# Immediately bail out if the action menu is open
 	if vm.action_menu and vm.action_menu.is_visible():
 		if vm.tooltip and vm.tooltip.visible:
@@ -302,8 +293,6 @@ func ev_mouse_enter_inventory_item(obj):
 func ev_mouse_exit_item(obj):
 	printt(obj.name, "mouse_exit_item")
 
-	vm.clear_overlapped_obj()
-
 	if vm.action_menu and vm.action_menu.is_visible():
 		return
 
@@ -339,8 +328,6 @@ func ev_mouse_enter_trigger(obj):
 	if inventory and inventory.blocks_tooltip():
 		return
 
-	vm.set_overlapped_obj(obj)
-
 	if vm.tooltip:
 		var tt = obj.get_tooltip()
 
@@ -358,7 +345,6 @@ func ev_mouse_enter_trigger(obj):
 func ev_mouse_exit_trigger(obj):
 	printt(obj.name, "mouse_exit_trigger")
 
-	vm.clear_overlapped_obj()
 	# FIXME: Action menu on item, click trigger which causes dialog, hover_object is not set, but should be
 	if vm.hover_object:
 		vm.hover_end()

--- a/device/globals/game.gd
+++ b/device/globals/game.gd
@@ -244,6 +244,8 @@ func ev_mouse_enter_item(obj):
 
 	printt(obj.name, "mouse_enter_item")
 
+	vm.hover_push(obj)
+
 	# Immediately bail out if the action menu is open
 	if vm.action_menu and vm.action_menu.is_visible():
 		if vm.tooltip and vm.tooltip.visible:
@@ -265,8 +267,6 @@ func ev_mouse_enter_item(obj):
 			# the tooltip may be emptied by the light not having a tooltip. This is because the
 			# `mouse_enter` events have no guaranteed order.
 			return
-
-	vm.hover_begin(obj)
 
 func ev_mouse_enter_inventory_item(obj):
 	if not inventory:
@@ -300,7 +300,7 @@ func ev_mouse_exit_item(obj):
 	if inventory and inventory.blocks_tooltip():
 		return
 
-	vm.hover_end()
+	vm.hover_pop(obj)
 
 func ev_mouse_exit_inventory_item(obj):
 	printt(obj.name, "mouse_exit_inventory_item")

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -162,7 +162,7 @@ func hover_push(obj):
 		if for_else:
 			hover_stack.push_back(obj)
 
-	hover_debug("PUSH")
+	# hover_debug("PUSH")
 	if need_new_hover:
 		# hover_debug("PUSHED, hovering " + obj.global_id)
 		hover_begin(obj)
@@ -188,7 +188,7 @@ func hover_pop(obj):
 				hover_stack.remove(i)
 				break
 
-	hover_debug("POP")
+	# hover_debug("POP")
 	if not hover_stack:
 		# printt("\tENDING ALL HOVERS", hover_object)
 		hover_end()

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -34,6 +34,7 @@ var camera
 
 ## One game, one VM; there are many things we can have only one of, track them here.
 var action_menu = null	   # If the game uses an action menu, register it here
+var inventory = null       # Register an inventory if used
 var tooltip = null         # The tooltip scene, registered by game.gd
 var hover_object = null    # Best-effort attempt to track what's under the mouse
 var hover_stack = []       # Register mouse_enter events here based on z-index
@@ -576,6 +577,16 @@ func register_action_menu(p_action_menu):
 			report_errors("global_vm", ["Trying to register non-ACTION_MENU type action_menu"])
 
 	action_menu = p_action_menu
+
+func register_inventory(p_inventory):
+	if inventory and p_inventory != inventory:
+		if not p_inventory is esc_type.INVENTORY:
+			report_errors("global_vm", ["Trying to re-register non-INVENTORY type inventory"])
+	elif not inventory:
+		if not p_inventory is esc_type.INVENTORY:
+			report_errors("global_vm", ["Trying to register non-INVENTORY type inventory"])
+
+	inventory = p_inventory
 
 func get_object(name):
 	if !(name in objects):

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -36,7 +36,6 @@ var camera
 var action_menu = null	   # If the game uses an action menu, register it here
 var tooltip = null         # The tooltip scene, registered by game.gd
 var hover_object = null    # Best-effort attempt to track what's under the mouse
-var overlapped_obj = null  # Would be covered by eg. a collapsible inventory ("cache" tooltip)
 
 var current_action = ""    # Verb or action menu button
 var current_tool = null    # Item chosen from inventory
@@ -419,9 +418,6 @@ func event_done(ev_name):
 			main.telon.cut_to_scene()
 	else:
 		if "NO_TT" in running_event.ev_flags:
-			# Let an `overlapped_obj` deal with the tooltip if required
-			reset_overlapped_obj()
-
 			# If the event was NO_TT, explicitly or because of `say`, we shouldn't keep it hidden
 			if tooltip.force_hide_tooltip:
 				tooltip.force_tooltip_visible(true)
@@ -598,28 +594,6 @@ func set_current_tool(p_tool):
 
 func clear_current_tool():
 	current_tool = null
-
-func set_overlapped_obj(obj):
-	if not obj is esc_type.ITEM and not obj is esc_type.TRIGGER:
-		report_errors("global_vm", ["Trying to set overlapped object " + obj.global_id + " which is not ITEM or TRIGGER"])
-
-	if obj is esc_type.ITEM and obj.inventory:
-		report_errors("global_vm", ["Trying to set overlapped inventory object " + obj.global_id])
-
-	overlapped_obj = obj
-
-func reset_overlapped_obj():
-	if overlapped_obj:
-		if overlapped_obj is esc_type.ITEM:
-			if overlapped_obj.inventory:
-				report_errors("global_vm", ["Trying to reset overlapped inventory item"])
-
-			overlapped_obj.emit_signal("mouse_enter_item", overlapped_obj)
-		elif overlapped_obj is esc_type.TRIGGER:
-			overlapped_obj.emit_signal("mouse_enter_trigger", overlapped_obj)
-
-func clear_overlapped_obj():
-	overlapped_obj = null
 
 func object_exit_scene(name):
 	objects.erase(name)

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -219,6 +219,10 @@ func hover_end():
 	if tooltip:
 		tooltip.update()
 
+func hover_clear_stack():
+	hover_stack = []
+	hover_object = null
+
 func camera_set_target(p_speed, p_target):
 	if not camera:
 		return

--- a/device/globals/hud.gd
+++ b/device/globals/hud.gd
@@ -24,7 +24,6 @@ func menu_opened():
 	hide()
 
 func menu_closed():
-	vm.reset_overlapped_obj()
 	show()
 
 func set_visible(p_visible):

--- a/device/globals/inventory.gd
+++ b/device/globals/inventory.gd
@@ -76,10 +76,6 @@ func close():
 	hide()
 	print("inventory close")
 
-	# Reset immediately only when there isn't an animation, otherwise let the handler do it
-	if not closing_animation:
-		vm.reset_overlapped_obj()
-
 func force_close():
 	if !is_visible():
 		return
@@ -99,7 +95,6 @@ func toggle():
 func anim_finished(name):
 	if name == "hide":
 		hide()
-		vm.reset_overlapped_obj()
 
 func sort_items():
 	var items = get_node("items")

--- a/device/globals/inventory.gd
+++ b/device/globals/inventory.gd
@@ -24,13 +24,6 @@ func open():
 	if is_visible():
 		return
 
-	if vm.tooltip:
-		# Anything left underneath the inventory is not considered hovering
-		if vm.hover_object:
-			vm.hover_end()
-
-		vm.tooltip.update()
-
 	if vm.action_menu:
 		# `false` is for show_tooltip=false
 		vm.action_menu.stop(false)
@@ -44,29 +37,28 @@ func open():
 	if has_node("animation"):
 		get_node("animation").play("show")
 
+func show():
+	.show()
+
+	if vm.tooltip:
+		vm.tooltip.update()
 
 func close():
 	if !is_visible():
 		return
 
 	if vm.tooltip:
-		# We want to hide the tooltip from a collapsible inventory, but not if
-		# an item has been selected as `current_tool`.
-		if not vm.current_tool:
-			vm.tooltip.hide()
-		# But if we are closing while hovering ...
-		elif vm.hover_object:
+		# If we are closing while hovering ...
+		if vm.hover_object:
 			# ... an inventory item ...
 			if vm.hover_object is esc_type.ITEM and vm.hover_object.inventory:
 				# ... we must exit it to sort out the tooltip
 				vm.hover_object.emit_signal("mouse_exit_inventory_item", vm.hover_object)
 
-	var closing_animation = false
 	if has_node("animation"):
 		if $"animation".is_playing():
 			return
 		$"animation".play("hide")
-		closing_animation = true
 
 	# XXX: What is this `look` node? A verb menu thing?
 	if has_node("look"):
@@ -75,6 +67,12 @@ func close():
 	current_action = ""
 	hide()
 	print("inventory close")
+
+func hide():
+	.hide()
+
+	if vm.tooltip:
+		vm.tooltip.update()
 
 func force_close():
 	if !is_visible():

--- a/device/globals/item.gd
+++ b/device/globals/item.gd
@@ -117,7 +117,7 @@ func input(event):
 	# TODO: Expand this for other input events than mouse
 	if event is InputEventMouseButton || event.is_action("ui_accept"):
 		if event.is_pressed():
-			clicked = true
+			clicked = vm.hover_stack.front() == self
 
 			var ev_pos = get_global_mouse_position()
 			if event.button_index == BUTTON_LEFT:
@@ -139,9 +139,6 @@ func input(event):
 				else:
 					emit_signal("right_click_on_item", self, ev_pos, event)
 			_check_focus(true, true)
-		else:
-			clicked = false
-#			_check_focus(true, false)
 
 func _check_focus(focus, pressed):
 	if has_node("_focus_in"):

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -21,6 +21,7 @@ func clear_scene():
 	vm.clear_current_tool()
 	if vm.hover_object:
 		vm.hover_end()
+	vm.inventory = null
 
 	get_node("/root").remove_child(current)
 	current.free()

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -17,7 +17,6 @@ func clear_scene():
 	if current == null:
 		return
 
-	vm.clear_overlapped_obj()
 	vm.clear_current_action()
 	vm.clear_current_tool()
 	if vm.hover_object:

--- a/device/globals/main.gd
+++ b/device/globals/main.gd
@@ -19,9 +19,10 @@ func clear_scene():
 
 	vm.clear_current_action()
 	vm.clear_current_tool()
-	if vm.hover_object:
-		vm.hover_end()
+	vm.hover_clear_stack()
 	vm.inventory = null
+	vm.tooltip = null
+	vm.action_menu = null
 
 	get_node("/root").remove_child(current)
 	current.free()

--- a/device/globals/tooltip.gd
+++ b/device/globals/tooltip.gd
@@ -11,9 +11,6 @@ func show():
 	if not self.text:
 		var errors = ["Trying to show empty tooltip"]
 
-		if vm.overlapped_obj:
-			errors.push_back("Overlapped object: " + vm.overlapped_obj.global_id)
-
 		if vm.hover_obj:
 			errors.push_back("Hovered object: " + vm.hover_obj.global_id)
 
@@ -60,7 +57,6 @@ func set_tooltip(text):
 		vm.report_errors("tooltip", ["Trying to set tooltip of type: " + str(typeof(text))])
 
 	if force_hide_tooltip:
-		# vm.reset_overlapped_obj()
 		if self.visible:
 			vm.report_errors("tooltip", ["Forcibly hidden tooltip visible while trying to set text: " + text])
 		return

--- a/device/globals/tooltip.gd
+++ b/device/globals/tooltip.gd
@@ -34,14 +34,27 @@ func update():
 		var tt = vm.hover_object.get_tooltip()
 
 		if vm.current_action and vm.current_tool and vm.current_tool != vm.hover_object:
-			text = tr(vm.current_action + ".combine_id")
-			text = text.replace("%2", tr(tt))
-			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
+			if not "inventory" in vm.hover_object or not vm.hover_object.inventory:
+				if not vm.inventory or not vm.inventory.blocks_tooltip():
+					text = tr(vm.current_action + ".combine_id")
+					text = text.replace("%2", tr(tt))
+					text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
+				else:
+					text = tr("use.id")
+					text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
+			else:
+					text = tr(vm.current_action + ".combine_id")
+					text = text.replace("%2", tr(tt))
+					text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
 		elif vm.current_action == "use" and vm.current_tool:
 			text = tr("use.id")
 			text = text.replace("%1", tr(vm.current_tool.get_tooltip()))
 		else:
-			text = tr(tt)
+			if not "inventory" in vm.hover_object or not vm.hover_object.inventory:
+				if not vm.inventory or not vm.inventory.blocks_tooltip():
+					text = tr(tt)
+			else:
+					text = tr(tt)
 	else:
 		if vm.current_action and vm.current_tool:
 			if not vm.hover_object:

--- a/device/globals/tooltip.gd
+++ b/device/globals/tooltip.gd
@@ -11,8 +11,8 @@ func show():
 	if not self.text:
 		var errors = ["Trying to show empty tooltip"]
 
-		if vm.hover_obj:
-			errors.push_back("Hovered object: " + vm.hover_obj.global_id)
+		if vm.hover_object:
+			errors.push_back("Hovered object: " + vm.hover_object.global_id)
 
 		vm.report_errors("tooltip", errors)
 

--- a/device/globals/tooltip.gd
+++ b/device/globals/tooltip.gd
@@ -25,6 +25,9 @@ func hide():
 	set_tooltip_visible(false)
 
 func update():
+	if vm.action_menu and vm.action_menu.visible:
+		return
+
 	var text = ""
 
 	if vm.hover_object:

--- a/device/globals/trigger.gd
+++ b/device/globals/trigger.gd
@@ -6,7 +6,6 @@ signal mouse_exit_trigger
 export var tooltip = ""
 
 var hud
-var inventory
 
 func get_tooltip():
 	if TranslationServer.get_locale() == ProjectSettings.get_setting("escoria/platform/development_lang"):
@@ -38,12 +37,7 @@ func input(event):
 		return
 
 	# Do not allow input on triggers/exits with inventory open
-	hud = $"/root/scene/game/hud_layer/hud"
-
-	if hud.has_node("inventory"):
-		inventory = hud.get_node("inventory")
-
-	if inventory and inventory.blocks_tooltip():
+	if vm.inventory and vm.inventory.blocks_tooltip():
 		return
 
 	if vm.action_menu and vm.action_menu.is_visible():


### PR DESCRIPTION
To ease the frustration of #221 I started prototyping quickly with using z-indexes instead of a new `interact_layer` thing.

It's not the cleanest set of patches, but these aren't the best of times to focus on style.

As for z-indexes, them colliding should be rare enough that the behavior can be undefined by design (as it is with Godot itself).

Too bad it doesn't fix issues that seem to relate to events, like having the tooltip visible for a while after dialog if the cursor is moved or any of that. Maybe Godot is broken.

On the upside, it gets rid of some magic like the `overlapped_obj` hack, beside allowing areas to overlap. How a collapsible inventory interacts with the tooltip is also safely tucked away behind standard APIs.

The code has not been tested against the Lunar Adventure codebase, but considering I spent hours longer on this than I would have had time for, I'm pretty sure it'll work.

@StraToN opionions?
