### PR TITLE
for 3.1 branch - rename local variables that shadow globals

### DIFF
--- a/device/globals/dialog_instance.gd
+++ b/device/globals/dialog_instance.gd
@@ -100,27 +100,27 @@ func finish():
 	elif not animation:
 		_queue_free()
 
-func _clamp(dialog_pos):
+func _clamp(p_dialog_pos):
 	var width = float(ProjectSettings.get("display/window/size/width"))
 	var height = float(ProjectSettings.get("display/window/size/height"))
 	var my_size = $"anchor/text".get_size()
 	var center_offset = my_size.x / 2
 
-	var dist_from_right = width - (dialog_pos.x + center_offset)
-	var dist_from_left = dialog_pos.x - center_offset
-	var dist_from_bottom = height - (dialog_pos.y + my_size.y)
-	var dist_from_top = dialog_pos.y - my_size.y
+	var dist_from_right = width - (p_dialog_pos.x + center_offset)
+	var dist_from_left = p_dialog_pos.x - center_offset
+	var dist_from_bottom = height - (p_dialog_pos.y + my_size.y)
+	var dist_from_top = p_dialog_pos.y - my_size.y
 
 	if dist_from_right < 0:
-		dialog_pos.x += dist_from_right
+		p_dialog_pos.x += dist_from_right
 	if dist_from_left < 0:
-		dialog_pos.x -= dist_from_left
+		p_dialog_pos.x -= dist_from_left
 	if dist_from_bottom < 0:
-		dialog_pos.y += dist_from_bottom
+		p_dialog_pos.y += dist_from_bottom
 	if dist_from_top < 0:
-		dialog_pos.y -= dist_from_top
+		p_dialog_pos.y -= dist_from_top
 
-	return dialog_pos
+	return p_dialog_pos
 
 func init(p_params, p_context, p_intro, p_outro):
 	character = vm.get_object(p_params[0])
@@ -287,8 +287,8 @@ func anim_finished(anim_name):
 	if cur == "hide":
 		_queue_free()
 
-func set_position(pos):
-	.set_position(_clamp(pos))
+func set_position(p_pos):
+	.set_position(_clamp(p_pos))
 
 func _ready():
 	var conn_err

--- a/device/globals/global_vm.gd
+++ b/device/globals/global_vm.gd
@@ -298,8 +298,8 @@ func inventory_has(p_obj):
 func inventory_set(p_obj, p_has):
 	set_global("i/"+p_obj, p_has)
 
-func say(params, level):
-	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "dialog", "say", params, level)
+func say(params, p_level):
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "dialog", "say", params, p_level)
 
 func set_hud_visible(p_visible):
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "hud", "set_visible", p_visible)
@@ -307,13 +307,13 @@ func set_hud_visible(p_visible):
 func dialog_config(params):
 	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "dialog", "config", params)
 
-func wait(params, level):
+func wait(params, p_level):
 	var time = float(params[0])
 	printt("wait time ", params[0], time)
 	if time <= 0:
 		return state_return
-	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "wait", time, level)
-	level.waiting = true
+	get_tree().call_group_flags(SceneTree.GROUP_CALL_DEFAULT, "game", "wait", time, p_level)
+	p_level.waiting = true
 	return state_yield
 
 func is_global_equal_to(name, val):
@@ -383,14 +383,14 @@ func test(cmd):
 
 	return true
 
-func dialog(params, level):
+func dialog(params, p_level):
 	set_hud_visible(false)
 
 	# Ensure tooltip is hidden. It may remain visible when the NPC finishes saying something
 	# and then `dialog` is called.
 	if tooltip:
 		tooltip.hide()
-	get_tree().call_group("dialog_dialog", "start", params, level)
+	get_tree().call_group("dialog_dialog", "start", params, p_level)
 
 #warning-ignore:unused_argument
 func end_dialog(params):
@@ -399,7 +399,7 @@ func end_dialog(params):
 
 
 func instance_level(p_event, p_root):
-	var level = {
+	var new_level = {
 		"ip": 0,
 		"instructions": p_event.ev_level,
 		"waiting": false,
@@ -411,8 +411,8 @@ func instance_level(p_event, p_root):
 	for i in range(p_event.ev_level.size()):
 		if p_event.ev_level[i].name == "label":
 			var lname = p_event.ev_level[i].params[0]
-			level.labels[lname] = i
-	return level
+			new_level.labels[lname] = i
+	return new_level
 
 func compile(p_path):
 
@@ -467,10 +467,10 @@ func add_level(p_event, p_root):
 
 	return state_call
 
-func _find_hiding_commands(level):
+func _find_hiding_commands(p_level):
 	# Recursive helper to see if we have the `say` command,
 	# so we can auto-hide a tooltip that follows the mouse
-	for command in level:
+	for command in p_level:
 		if command.name == "say":
 			return true
 		elif command.name == "change_scene":
@@ -480,10 +480,10 @@ func _find_hiding_commands(level):
 
 	return false
 
-func _find_accept_input(level):
+func _find_accept_input(p_level):
 	# Recursive helper to see if we have the `say` command,
 	# so we can set the acceptable input to INPUT_SKIP
-	for command in level:
+	for command in p_level:
 		if command.name == "say":
 			return acceptable_inputs.INPUT_SKIP
 		elif command.name == "branch":

--- a/device/project.godot
+++ b/device/project.godot
@@ -58,7 +58,6 @@ application/dialog_minimum_visible_seconds=1
 application/dialog_damp_music_by_db=3
 debug/tag_untranslated_strings=true
 debug/terminate_on_errors=true
-debug/terminate_on_errors=true
 platform/skip_cache=false
 platform/action_menu_scale=2
 platform/dialog_option_height=1


### PR DESCRIPTION
fix the errors when running the main scene with godot 3.1.1 in #267 