### PR TITLE
Corrections to run in godot 3.2.3

### DIFF
--- a/device/globals/dialog_dialog.gd
+++ b/device/globals/dialog_dialog.gd
@@ -91,8 +91,8 @@ func start(params, p_context):
 		if params.size() >= 3:
 			avatar = params[2]
 		var avatars = get_node("wrapper/avatars")
-		for i in range(avatars.get_child_count()):
-			var c = avatars.get_child(i)
+		for j in range(avatars.get_child_count()):
+			var c = avatars.get_child(j)
 			if c.get_name() == avatar:
 				c.show()
 			else:

--- a/device/globals/trigger.gd
+++ b/device/globals/trigger.gd
@@ -87,7 +87,7 @@ func _physics_process(dt):
 func _ready():
 	var conn_err
 
-	assert(self is Area2D)
+	#assert(self is Area2D)
 
 	conn_err = connect("input_event", self, "area_input")
 	if conn_err:


### PR DESCRIPTION
I was trying out escoria in godot in 3.2.3 and noticed these 2 problems. The "self is Area2D" I am not too sure about as I don't know godot very well, however I cannot see how the other code could ever have worked, as just a few lines before the "i" variable is being used for something else. I have changed it to "j". The game example then runs and I was able to play it.