### PR TITLE
Fix settings being applied a second time with wrong data

### DIFF
--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -192,7 +192,7 @@ func save_settings():
 			["There was an issue writing settings %s" % save_path])
 
 # Load the game settings from the settings file
-func load_settings():
+func load_settings() -> Resource:
 	var save_settings_path: String = settings_folder.plus_file(SETTINGS_TEMPLATE)
 	var file: File = File.new()
 	if not file.file_exists(save_settings_path):
@@ -201,7 +201,5 @@ func load_settings():
 			["Settings file %s doesn't exist" % save_settings_path,
 			"Setting default settings."])
 		save_settings()
-		return
 
-	var settings_resource: Resource = load(save_settings_path)
-	escoria._on_settings_loaded(settings_resource)
+	return load(save_settings_path)

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -192,6 +192,7 @@ func save_settings():
 			["There was an issue writing settings %s" % save_path])
 
 # Load the game settings from the settings file
+# **Returns** The Resource structure loaded from settings file
 func load_settings() -> Resource:
 	var save_settings_path: String = settings_folder.plus_file(SETTINGS_TEMPLATE)
 	var file: File = File.new()

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -93,13 +93,11 @@ func _init():
 	self.resource_cache.start()
 	self.save_manager = ESCSaveManager.new()
 
-
 # Load settings
 func _ready():
 	settings = ESCSaveSettings.new()
 	settings = save_manager.load_settings()
 	escoria._on_settings_loaded(escoria.settings)
-
 
 # Called by Main menu "start new game"
 func new_game():

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -93,11 +93,13 @@ func _init():
 	self.resource_cache.start()
 	self.save_manager = ESCSaveManager.new()
 
+
 # Load settings
 func _ready():
 	settings = ESCSaveSettings.new()
 	settings = save_manager.load_settings()
 	escoria._on_settings_loaded(escoria.settings)
+
 
 # Called by Main menu "start new game"
 func new_game():
@@ -383,5 +385,4 @@ func _on_settings_loaded(p_settings: ESCSaveSettings) -> void:
 		linear2db(settings.music_volume)
 	)
 	TranslationServer.set_locale(settings.text_lang)
-#	music_volume_changed()
 

--- a/game/ui/commons/options/options.gd
+++ b/game/ui/commons/options/options.gd
@@ -7,12 +7,12 @@ onready var backup_settings
 
 
 func _ready():
-	initialize_options(escoria.settings)
+	pass
 
 
 func show():
 	backup_settings = escoria.settings.duplicate()
-	initialize_options(backup_settings)
+	initialize_options(escoria.settings)
 	visible = true
 
 

--- a/game/ui/commons/options/options.gd
+++ b/game/ui/commons/options/options.gd
@@ -3,11 +3,7 @@ extends Control
 signal back_button_pressed
 
 onready var settings_changed = false
-onready var backup_settings
-
-
-func _ready():
-	pass
+var backup_settings
 
 
 func show():


### PR DESCRIPTION
This PR fixes an issue with the settings loading workflow, that led the settings to be applied twice after loading. Second call was called too soon with data not loaded already.