### PR TITLE
Fix tooltip_node wrong references

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_tooltip.gd
+++ b/addons/escoria-core/game/core-scripts/esc_tooltip.gd
@@ -1,46 +1,69 @@
+# A tooltip displaying <verb> <item1> [<item2>] 
+
 tool
 extends RichTextLabel
 class_name ESCTooltip
 
-func get_class():
-	return "ESCTooltip"
-
-
 # Infinitive verb
 var current_action: String
+
 # Target item/hotspot
 var current_target: String setget set_target
+
 # Preposition: on, with...
 var current_prep: String = "with"
+
 # Target 2 item/hotspot
 var current_target2: String
+
 # True if tooltip is waiting for a click on second target (use x with y)
 var waiting_for_target2 = false
 
+# Color of the label
 export(Color) var color setget set_color
+
+# Vector2 defining the offset from the cursor
 export(Vector2) var offset_from_cursor = Vector2(10,0)
 
+# Activates debug mode. If enabled, shows the label with a white background.
 export(bool) var debug_mode = false setget set_debug_mode
+
+# Node containing the debug white background
 var debug_texturerect_node: TextureRect
 
+# Maximum width of the label
 const MAX_WIDTH = 200
+
+# Minimum height of the label
 const MIN_HEIGHT = 30
+
+# Maximum height of the label
 const MAX_HEIGHT = 500
+
+# Height of one line in the label
 const ONE_LINE_HEIGHT = 16
 
 
-
+# Ready function
 func _ready():
-	if escoria.main.current_scene:
-		escoria.main.current_scene.game.tooltip_node = self
-	escoria.action_manager.connect("action_changed", self, "on_action_selected")
+	escoria.main.connect("room_ready", self, "_on_room_ready")
+	escoria.action_manager.connect("action_changed", self, "_on_action_selected")
 	
-
+	
+# Set the color of the label
+#
+# ## Parameters
+# - p_color: the color to set the label
 func set_color(p_color: Color):
 	color = p_color
 	update_tooltip_text()
 
 
+# Enable/disable debug mode of the label. If enabled, the label is displayed 
+# with a white background.
+# 
+# ## Parameters
+# - p_debug_mode: if true, enable debug mode. False to disable
 func set_debug_mode(p_debug_mode: bool):
 	debug_mode = p_debug_mode
 	if debug_mode:
@@ -61,12 +84,18 @@ func set_debug_mode(p_debug_mode: bool):
 		if debug_texturerect_node:
 			remove_child(debug_texturerect_node)
 	
-
-func on_action_selected() -> void:
+	
+# Called when an action is selected in Escoria
+func _on_action_selected() -> void:
 	current_action = escoria.action_manager.current_action
 	update_tooltip_text()
 
 
+# Set the first target of the label.
+#
+# ## Parameters
+# - target: String the target to add to the label
+# - needs_second_target: if true, the label will prepare for a second target
 func set_target(target: String, needs_second_target: bool = false) -> void:
 	current_target = target
 	if needs_second_target:
@@ -74,12 +103,16 @@ func set_target(target: String, needs_second_target: bool = false) -> void:
 	update_tooltip_text()
 
 
+# Set the second target of the label
+#
+# ## Parameters
+# - target2: String the second target to add to the label
 func set_target2(target2: String) -> void:
 	current_target2 = target2
 	update_tooltip_text()
 
 
-
+# Update the tooltip text.
 func update_tooltip_text():
 	"""
 	Overriden method. Should not be called directly.
@@ -87,7 +120,7 @@ func update_tooltip_text():
 	pass
 
 
-
+# Update the tooltip size according to the text.
 func update_size():
 	## RECT_SIZE ##
 	var rtl_width = rect_size.x
@@ -132,7 +165,14 @@ func update_size():
 #	printt("AFTER", "text_height", get_content_height(), "rtl_height", rect_size.y)
 
 
-func _offset(position):
+# Calculate the offset of the label depending on its position.
+# 
+# ## Parameters
+# - position: the position to test
+#
+# **Return**
+# The calculated offset
+func _offset(position: Vector2) -> Vector2:
 	var center_offset_x = rect_size.x / 2
 	var offset_y = 5
 	
@@ -142,19 +182,56 @@ func _offset(position):
 	return position
 
 
+# Return the tooltip distance to top edge.
+#
+# ## Parameters
+# - position: the position to test
+#
+# **Return**
+# The distance to the edge.
 func tooltip_distance_to_edge_top(position: Vector2):
 	return position.y
 
+
+# Return the tooltip distance to bottom edge.
+#
+# ## Parameters
+# - position: the position to test
+#
+# **Return**
+# The distance to the edge.
 func tooltip_distance_to_edge_bottom(position: Vector2):
 	return escoria.game_size.y - position.y
 
+
+# Return the tooltip distance to left edge.
+#
+# ## Parameters
+# - position: the position to test
+#
+# **Return**
+# The distance to the edge.
 func tooltip_distance_to_edge_left(position: Vector2):
 	return position.x
 
+
+# Return the tooltip distance to right edge.
+#
+# ## Parameters
+# - position: the position to test
+#
+# **Return**
+# The distance to the edge.
 func tooltip_distance_to_edge_right(position: Vector2):
 	return escoria.game_size.x - position.x
 
 
+# Clear the tooltip targets texts
 func clear():
 	set_target("")
 	set_target2("")
+
+
+# Called when the room is loaded to setup the label.
+func _on_room_ready():
+	escoria.main.current_scene.game.tooltip_node = self

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -3,6 +3,10 @@ extends Node
 
 # This script is basically the scene-switcher.
 
+
+signal room_ready
+
+
 # Global id of the last scene the player was before current scene
 var last_scene_global_id: String
 
@@ -46,6 +50,8 @@ func set_scene(p_scene: Node) -> void:
 	check_game_scene_methods()
 
 	set_camera_limits()
+	
+	emit_signal("room_ready")
 
 
 # Cleanup the current scene

--- a/addons/escoria-ui-simplemouse/game.tscn
+++ b/addons/escoria-ui-simplemouse/game.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=8 format=2]
 
-[ext_resource path="res://game/ui/ui_mouse_icons/inventory/inventory_ui.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/escoria-ui-simplemouse/inventory/inventory_ui.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/escoria-core/game/scenes/dialogs/dialog_player.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/escoria-core/game/scenes/camera_player/camera.tscn" type="PackedScene" id=3]
-[ext_resource path="res://game/ui/ui_mouse_icons/verbs_mouseicons.tscn" type="PackedScene" id=4]
-[ext_resource path="res://game/ui/ui_mouse_icons/game.gd" type="Script" id=5]
-[ext_resource path="res://game/ui/ui_mouse_icons/tooltip/target_tooltip.tscn" type="PackedScene" id=6]
+[ext_resource path="res://addons/escoria-ui-simplemouse/verbs_mouseicons.tscn" type="PackedScene" id=4]
+[ext_resource path="res://addons/escoria-ui-simplemouse/game.gd" type="Script" id=5]
+[ext_resource path="res://addons/escoria-ui-simplemouse/tooltip/target_tooltip.tscn" type="PackedScene" id=6]
 [ext_resource path="res://game/ui/commons/room_select.tscn" type="PackedScene" id=7]
 
 [node name="game" type="Node2D"]

--- a/addons/escoria-ui-simplemouse/inventory/inventory_ui.tscn
+++ b/addons/escoria-ui-simplemouse/inventory/inventory_ui.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/escoria-core/game/scenes/inventory/inventory_ui.gd" type="Script" id=1]
-[ext_resource path="res://game/ui/ui_mouse_icons/images/inventory_bg.png" type="Texture" id=2]
-[ext_resource path="res://game/ui/ui_mouse_icons/inventory/inventory_ui_container.gd" type="Script" id=3]
-[ext_resource path="res://game/ui/ui_mouse_icons/inventory/inventory_showhide.gd" type="Script" id=4]
-[ext_resource path="res://game/ui/ui_mouse_icons/images/frame.png" type="Texture" id=5]
-[ext_resource path="res://game/ui/ui_mouse_icons/images/inventory_icon.png" type="Texture" id=6]
+[ext_resource path="res://addons/escoria-ui-simplemouse/images/inventory_bg.png" type="Texture" id=2]
+[ext_resource path="res://addons/escoria-ui-simplemouse/inventory/inventory_ui_container.gd" type="Script" id=3]
+[ext_resource path="res://addons/escoria-ui-simplemouse/inventory/inventory_showhide.gd" type="Script" id=4]
+[ext_resource path="res://addons/escoria-ui-simplemouse/images/frame.png" type="Texture" id=5]
+[ext_resource path="res://addons/escoria-ui-simplemouse/images/inventory_icon.png" type="Texture" id=6]
 
 [sub_resource type="Animation" id=1]
 resource_name = "hide"

--- a/addons/escoria-ui-simplemouse/tooltip/target_tooltip.tscn
+++ b/addons/escoria-ui-simplemouse/tooltip/target_tooltip.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://addons/escoria-core/game/assets/fonts/onesize/ONESIZE_.TTF" type="DynamicFontData" id=1]
-[ext_resource path="res://game/ui/ui_mouse_icons/tooltip/tooltip_target.gd" type="Script" id=2]
+[ext_resource path="res://addons/escoria-ui-simplemouse/tooltip/tooltip_target.gd" type="Script" id=2]
 
 [sub_resource type="DynamicFont" id=1]
 size = 30

--- a/addons/escoria-ui-simplemouse/verbs_mouseicons.tscn
+++ b/addons/escoria-ui-simplemouse/verbs_mouseicons.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=7 format=2]
 
-[ext_resource path="res://game/ui/ui_mouse_icons/verbs_mouseicons.gd" type="Script" id=1]
-[ext_resource path="res://game/ui/ui_mouse_icons/cursors/cursor_examine.png" type="Texture" id=2]
-[ext_resource path="res://game/ui/ui_mouse_icons/cursors/cursor_tool.png" type="Texture" id=3]
-[ext_resource path="res://game/ui/ui_mouse_icons/cursors/cursor_pen.png" type="Texture" id=4]
-[ext_resource path="res://game/ui/ui_mouse_icons/cursors/cursor_foot.png" type="Texture" id=5]
-[ext_resource path="res://game/ui/ui_mouse_icons/cursors/cursor_hand.png" type="Texture" id=6]
+[ext_resource path="res://addons/escoria-ui-simplemouse/verbs_mouseicons.gd" type="Script" id=1]
+[ext_resource path="res://addons/escoria-ui-simplemouse/cursors/cursor_examine.png" type="Texture" id=2]
+[ext_resource path="res://addons/escoria-ui-simplemouse/cursors/cursor_tool.png" type="Texture" id=3]
+[ext_resource path="res://addons/escoria-ui-simplemouse/cursors/cursor_pen.png" type="Texture" id=4]
+[ext_resource path="res://addons/escoria-ui-simplemouse/cursors/cursor_foot.png" type="Texture" id=5]
+[ext_resource path="res://addons/escoria-ui-simplemouse/cursors/cursor_hand.png" type="Texture" id=6]
 
 [node name="verbs_menu" type="Control"]
 script = ExtResource( 1 )
@@ -53,10 +53,10 @@ margin_bottom = 132.0
 texture = ExtResource( 4 )
 
 [node name="mouse_position" type="Control" parent="."]
-margin_left = 323.435
-margin_top = 57.9191
-margin_right = 323.435
-margin_bottom = 57.9191
+margin_left = 546.519
+margin_top = 524.76
+margin_right = 546.519
+margin_bottom = 524.76
 mouse_filter = 2
 
 [node name="tool" type="TextureRect" parent="mouse_position"]

--- a/docs/api/ESCTooltip.md
+++ b/docs/api/ESCTooltip.md
@@ -6,6 +6,8 @@
 
 ## Description
 
+A tooltip displaying <verb> <item1> [<item2>]
+
 ## Constants Descriptions
 
 ### MAX\_HEIGHT
@@ -14,11 +16,15 @@
 const MAX_HEIGHT: int = 500
 ```
 
+Maximum height of the label
+
 ### MAX\_WIDTH
 
 ```gdscript
 const MAX_WIDTH: int = 200
 ```
+
+Maximum width of the label
 
 ### MIN\_HEIGHT
 
@@ -26,11 +32,15 @@ const MAX_WIDTH: int = 200
 const MIN_HEIGHT: int = 30
 ```
 
+ Minimum height of the label
+
 ### ONE\_LINE\_HEIGHT
 
 ```gdscript
 const ONE_LINE_HEIGHT: int = 16
 ```
+
+Height of one line in the label
 
 ## Property Descriptions
 
@@ -84,11 +94,15 @@ export var color = "0,0,0,1"
 
 - **Setter**: `set_color`
 
+Color of the label
+
 ### offset\_from\_cursor
 
 ```gdscript
 export var offset_from_cursor = "(10, 0)"
 ```
+
+Vector2 defining the offset from the cursor
 
 ### debug\_mode
 
@@ -98,19 +112,17 @@ export var debug_mode = false
 
 - **Setter**: `set_debug_mode`
 
+Activates debug mode. If enabled, shows the label with a white background.
+
 ### debug\_texturerect\_node
 
 ```gdscript
 var debug_texturerect_node: TextureRect
 ```
 
+Node containing the debug white background
+
 ## Method Descriptions
-
-### get\_class
-
-```gdscript
-func get_class()
-```
 
 ### set\_color
 
@@ -118,17 +130,22 @@ func get_class()
 func set_color(p_color: Color)
 ```
 
+ Set the color of the label
+
+## Parameters
+ - p_color: the color to set the label
+
 ### set\_debug\_mode
 
 ```gdscript
 func set_debug_mode(p_debug_mode: bool)
 ```
 
-### on\_action\_selected
+ Enable/disable debug mode of the label. If enabled, the label is displayed
+with a white background.
 
-```gdscript
-func on_action_selected() -> void
-```
+## Parameters
+- p_debug_mode: if true, enable debug mode. False to disable
 
 ### set\_target
 
@@ -136,11 +153,22 @@ func on_action_selected() -> void
 func set_target(target: String, needs_second_target: bool = false) -> void
 ```
 
+ Set the first target of the label.
+
+## Parameters
+- target: String the target to add to the label
+- needs_second_target: if true, the label will prepare for a second target
+
 ### set\_target2
 
 ```gdscript
 func set_target2(target2: String) -> void
 ```
+
+ Set the second target of the label
+
+## Parameters
+- target2: String the second target to add to the label
 
 ### update\_tooltip\_text
 
@@ -148,11 +176,15 @@ func set_target2(target2: String) -> void
 func update_tooltip_text()
 ```
 
+Update the tooltip text.
+
 ### update\_size
 
 ```gdscript
 func update_size()
 ```
+
+Update the tooltip size according to the text.
 
 ### tooltip\_distance\_to\_edge\_top
 
@@ -160,11 +192,27 @@ func update_size()
 func tooltip_distance_to_edge_top(position: Vector2)
 ```
 
+Return the tooltip distance to top edge.
+
+## Parameters
+- position: the position to test
+
+**Return**
+The distance to the edge.
+
 ### tooltip\_distance\_to\_edge\_bottom
 
 ```gdscript
 func tooltip_distance_to_edge_bottom(position: Vector2)
 ```
+
+Return the tooltip distance to bottom edge.
+
+## Parameters
+- position: the position to test
+
+**Return**
+The distance to the edge.
 
 ### tooltip\_distance\_to\_edge\_left
 
@@ -172,11 +220,27 @@ func tooltip_distance_to_edge_bottom(position: Vector2)
 func tooltip_distance_to_edge_left(position: Vector2)
 ```
 
+Return the tooltip distance to left edge.
+
+## Parameters
+- position: the position to test
+
+**Return**
+The distance to the edge.
+
 ### tooltip\_distance\_to\_edge\_right
 
 ```gdscript
 func tooltip_distance_to_edge_right(position: Vector2)
 ```
+
+Return the tooltip distance to right edge.
+
+## Parameters
+- position: the position to test
+
+**Return**
+The distance to the edge.
 
 ### clear
 
@@ -184,3 +248,4 @@ func tooltip_distance_to_edge_right(position: Vector2)
 func clear()
 ```
 
+Clear the tooltip targets texts

--- a/docs/api/main.gd.md
+++ b/docs/api/main.gd.md
@@ -107,3 +107,7 @@ func check_game_scene_methods()
 Sanity check that the game.tscn scene's root node script MUST
 implement the following methods. If they do not exist, stop immediately.
 Implement them, even if empty
+
+## Signals
+
+- signal room_ready(): 

--- a/docs/esc.md
+++ b/docs/esc.md
@@ -406,6 +406,7 @@ Makes the `player` walk to the position `x`/`y`.
 
 
 
+
 ## Dialogs
 
 Dialogs are specified by writing `?` with optional parameters, followed by a list of dialog options starting with `-`. Use `!` to end the dialog.

--- a/project.godot
+++ b/project.godot
@@ -588,7 +588,7 @@ main/force_quit=true
 debug/terminate_on_warnings=false
 debug/terminate_on_errors=true
 debug/development_lang="en"
-ui/tooltip_follows_mouse=false
+ui/tooltip_follows_mouse=true
 ui/dialogs_folder="res://game/ui/commons/dialogs"
 ui/default_dialog_scene="res://game/ui/commons/dialogs/dialog_label.tscn"
 ui/main_menu_scene="res://game/ui/commons/main_menu/main_menu.tscn"
@@ -610,13 +610,13 @@ main/savegames_path="res://saves/"
 main/settings_path="user://"
 main/escoria_version=""
 sound/speech_enabled=1
-ui/game_scene="res://addons/escoria-ui-9verbs/game.tscn"
+ui/game_scene="res://addons/escoria-ui-simplemouse/game.tscn"
 
 [input]
 
 esc_show_debug_prompt={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777245,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777245,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 switch_action_verb={


### PR DESCRIPTION
Fixes #302

I had to move the tooltip_node reference from ESCGame to ESCMain because of the loading order induced.
I am not sure this is right though so I'm open to suggestions.