### PR TITLE
Add default behaviors in ESCGame click handlers on BG and items.

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc_game.gd
@@ -50,7 +50,7 @@ func _draw():
 #
 # - position: Position clicked
 func left_click_on_bg(position: Vector2) -> void:
-	pass
+	escoria.do("walk", ["player", position])
 
 
 # Called when the player right clicks on the background
@@ -60,7 +60,7 @@ func left_click_on_bg(position: Vector2) -> void:
 #
 # - position: Position clicked	
 func right_click_on_bg(position: Vector2) -> void:
-	pass
+	escoria.do("walk", ["player", position])
 
 
 # Called when the player double clicks on the background
@@ -70,7 +70,7 @@ func right_click_on_bg(position: Vector2) -> void:
 #
 # - position: Position clicked
 func left_double_click_on_bg(position: Vector2) -> void:
-	pass
+	escoria.do("walk", ["player", position, true])
 
 
 # Called when an element in the scene was focused
@@ -97,7 +97,7 @@ func element_unfocused() -> void:
 # - item_global_id: Global id of the item that was clicked
 # - event: The received input event
 func left_click_on_item(item_global_id: String, event: InputEvent) -> void:
-	pass
+	escoria.do("item_left_click", [item_global_id, event])
 
 
 # Called when an item was right clicked
@@ -108,7 +108,7 @@ func left_click_on_item(item_global_id: String, event: InputEvent) -> void:
 # - item_global_id: Global id of the item that was clicked
 # - event: The received input event
 func right_click_on_item(item_global_id: String, event: InputEvent) -> void:
-	pass
+	escoria.do("item_right_click", [item_global_id, event])
 
 
 # Called when an item was double clicked
@@ -122,7 +122,7 @@ func left_double_click_on_item(
 	item_global_id: String, 
 	event: InputEvent
 ) -> void:
-	pass
+	escoria.do("item_left_click", [item_global_id, event]) 
 
 
 # Called when an inventory item was left clicked

--- a/addons/escoria-ui-9verbs/game.gd
+++ b/addons/escoria-ui-9verbs/game.gd
@@ -52,10 +52,12 @@ func left_click_on_bg(position: Vector2) -> void:
 	escoria.action_manager.clear_current_action()
 	verbs_menu.unselect_actions()
 	
+	
 func right_click_on_bg(position: Vector2) -> void:
 	escoria.do("walk", ["player", position])
 	escoria.action_manager.clear_current_action()
 	verbs_menu.unselect_actions()
+	
 	
 func left_double_click_on_bg(position: Vector2) -> void:
 	escoria.do("walk", ["player", position, true])
@@ -74,18 +76,21 @@ func element_focused(element_id: String) -> void:
 		if target_obj is ESCItem:
 			verbs_menu.set_by_name(target_obj.default_action)
 
+
 func element_unfocused() -> void:
 	tooltip.clear()
 	verbs_menu.unselect_actions()
 
-## ITEMS ##
 
+## ITEMS ##
 func left_click_on_item(item_global_id: String, event: InputEvent) -> void:
 	escoria.do("item_left_click", [item_global_id, event])
+
 
 func right_click_on_item(item_global_id: String, event: InputEvent) -> void:
 	escoria.action_manager.set_current_action(verbs_menu.selected_action)
 	escoria.do("item_right_click", [item_global_id, event])
+
 
 func left_double_click_on_item(item_global_id: String, event: InputEvent) -> void:
 	escoria.do("item_left_click", [item_global_id, event]) 
@@ -100,8 +105,10 @@ func right_click_on_inventory_item(inventory_item_global_id: String, event: Inpu
 	escoria.action_manager.set_current_action(verbs_menu.selected_action)
 	escoria.do("item_right_click", [inventory_item_global_id, event])
 
+
 func left_double_click_on_inventory_item(_inventory_item_global_id: String, _event: InputEvent) -> void:
 	pass
+
 
 func inventory_item_focused(inventory_item_global_id: String) -> void:
 	var target_obj = escoria.object_manager.get_object(


### PR DESCRIPTION
Fixes #301 

This PR adds default behaviors in these functions:
- left_click_on_bg()
- right_click_on_bg()
- left_double_click_on_bg()
- left_click_on_item()
- right_click_on_item()
- left_double_click_on_item()

So that if these functions are *not* overridden in user's game.gd script, the default behavior will be used.
NB: if these function are overridden in user's game.gd script, these default behaviors will not be called (unless explicitly called using parent script call by adding a dot before the function: `.left_click_on_bg()`)