### PR TITLE
Removed hardcoded access to node named "sprite"

### DIFF
--- a/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
+++ b/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
@@ -301,13 +301,15 @@ func update_terrain(on_event_finished_name = null) -> void:
 	var color = parent.terrain.get_light(pos)
 	parent.modulate = color
 
+	var sprite: Node = parent.get_sprite()
+	
 	# Do not flip the entire character, because that would conflict
 	# with shadows that expect to be siblings of $texture
-	if pose_scale == -1 and parent.get_node("sprite").scale.x > 0:
-		parent.get_node("sprite").scale.x *= pose_scale
+	if pose_scale == -1 and sprite.scale.x > 0:
+		sprite.scale.x *= pose_scale
 		parent.collision.scale.x *= pose_scale
-	elif pose_scale == 1 and parent.get_node("sprite").scale.x < 0:
-		parent.get_node("sprite").scale.x *= -1
+	elif pose_scale == 1 and sprite.scale.x < 0:
+		sprite.scale.x *= -1
 		parent.collision.scale.x *= -1
 
 

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -127,6 +127,12 @@ export(NodePath) var animation_player_node: NodePath = "" \
 # ESCAnimationsResource (for walking, idling...)
 var animations: ESCAnimationResource
 
+# Reference to the animation node (null if none was found)
+var animation_sprite = null
+
+# Reference to the sprite node
+var _sprite_node: Node = null
+
 # Reference to the current terrain
 var terrain: ESCTerrain
 
@@ -329,6 +335,19 @@ func set_speed(speed_value: int) -> void:
 # Check wether this item moved
 func has_moved() -> bool:
 	return _movable.moved if is_movable else false
+
+
+# Return the sprite node
+func get_sprite() -> Node:
+	if _sprite_node == null:
+		for child in self.get_children():
+			if child is AnimatedSprite or child is Sprite:
+				_sprite_node = child
+	if _sprite_node == null:
+		escoria.logger.error(
+			"No sprite node found in the scene %s" % get_path()
+		)
+	return _sprite_node
 
 
 # Set the angle

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -87,9 +87,9 @@ func left_click_on_inventory_item(inventory_item_global_id: String, event: Input
 		var item = escoria.object_manager.get_object(
 			inventory_item_global_id
 		).node
-		if item.get_node("sprite").texture:
+		if item.has_method("get_sprite") and item.get_sprite().texture:
 			$ui/verbs_layer/verbs_menu.set_tool_texture(
-				item.get_node("sprite").texture
+				item.get_sprite().texture
 			)
 		elif item.inventory_item.texture_normal:
 			$ui/verbs_layer/verbs_menu.set_tool_texture(

--- a/docs/api/ESCItem.md
+++ b/docs/api/ESCItem.md
@@ -336,6 +336,14 @@ func has_moved() -> bool
 
 Check wether this item moved
 
+### get\_sprite
+
+```gdscript
+func get_sprite() -> Node
+```
+
+Return the sprite node
+
 ### set\_angle
 
 ```gdscript


### PR DESCRIPTION
Fixes #304

Allows user to name the Sprite/AnimatedSprite node in ESCItem any name.