### PR TITLE
fix: FIxed non-editor call to _set_animation_player

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -415,6 +415,9 @@ func _get_property_list():
 #
 # - node_path: Path to the player node
 func _set_animation_player_node(node_path: NodePath):
+	if not Engine.is_editor_hint():
+		return
+	
 	if node_path == "":
 		animation_player_node = node_path
 		return

--- a/docs/api/ESCItem.md
+++ b/docs/api/ESCItem.md
@@ -204,6 +204,14 @@ var animations: ESCAnimationResource
 
  ESCAnimationsResource (for walking, idling...)
 
+### animation\_sprite
+
+```gdscript
+var animation_sprite
+```
+
+Reference to the animation node (null if none was found)
+
 ### terrain
 
 ```gdscript

--- a/game/characters/mark/mark.tscn
+++ b/game/characters/mark/mark.tscn
@@ -204,6 +204,7 @@ script = ExtResource( 1 )
 global_id = "player"
 is_movable = true
 dialog_color = Color( 1, 1, 1, 1 )
+animation_player_node = NodePath("sprite")
 animations = ExtResource( 3 )
 
 [node name="sprite" type="AnimatedSprite" parent="."]


### PR DESCRIPTION
This fixes calls to the setter for animation_player when the player is running the game, which resulted in a crash.