### PR TITLE
Make ESCLocation is_start_location work

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
@@ -53,7 +53,8 @@ func run(command_params: Array) -> int:
 		command_params[2]
 	])
 	
-	if escoria.main.current_scene:
+	if escoria.main.current_scene \
+		and not escoria.globals_manager.get_global("BYPASS_LAST_SCENE"):
 		escoria.globals_manager.set_global(
 			"ESC_LAST_SCENE", 
 			escoria.main.current_scene.global_id, 
@@ -112,5 +113,13 @@ func run(command_params: Array) -> int:
 			]
 		)
 		return ESCExecution.RC_ERROR
+	
+	# If the ESC_LAST_SCENE global was bypassed, reset bypass variable to false
+	if escoria.globals_manager.get_global("BYPASS_LAST_SCENE"):
+		escoria.globals_manager.set_global(
+			"BYPASS_LAST_SCENE", 
+			false, 
+			true
+		)
 
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
@@ -11,7 +11,8 @@ signal global_changed(global, old_value, new_value)
 
 # A list of reserved globals which can not be overridden
 const RESERVED_GLOBALS = [
-	"ESC_LAST_SCENE"
+	"ESC_LAST_SCENE",
+	"BYPASS_LAST_SCENE"
 ]
 
 
@@ -22,6 +23,7 @@ export(Dictionary) var _globals = {}
 
 func _init():
 	set_global("ESC_LAST_SCENE", "", true)
+	set_global("BYPASS_LAST_SCENE", false, true)
 
 
 # Check if a global was registered

--- a/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
@@ -83,8 +83,9 @@ func get_object(global_id: String) -> ESCObject:
 		return objects[global_id]
 	else:
 		escoria.logger.report_warnings(
-			"Invalid object retrieved",
+			"esc_object_manager.gd:get_object()",
 			[
+				"Invalid object retrieved",
 				"Object with global id %s not found" % global_id
 			]
 		)
@@ -119,3 +120,17 @@ func save_game(p_savegame: ESCSaveGame) -> void:
 			continue
 		p_savegame.objects[obj_global_id] = \
 			objects[obj_global_id].get_save_data()
+
+
+func get_start_location() -> ESCLocation:
+	for object in objects.values():
+		if object.node is ESCLocation and object.node.is_start_location:
+			return object
+	escoria.logger.report_warnings(
+			"esc_object_manager.gd:get_start_location()",
+			[
+				"Room has no ESCLocation node with 'is_start_location' enabled.",
+				"Player will be set at position (0,0) by default."
+			]
+		)
+	return null

--- a/addons/escoria-core/game/core-scripts/esc_room.gd
+++ b/addons/escoria-core/game/core-scripts/esc_room.gd
@@ -98,6 +98,13 @@ func _ready():
 		if rc[0] != ESCExecution.RC_OK:
 			return rc[0]
 		
+		if (escoria.globals_manager.get_global("ESC_LAST_SCENE") == null \
+			or escoria.globals_manager.get_global("ESC_LAST_SCENE").empty()) \
+			and player != null \
+			and escoria.object_manager.get_start_location() != null:
+			player.teleport(escoria.object_manager.get_start_location().node)
+			
+		
 		escoria.main.scene_transition.transition()
 		yield(escoria.main.scene_transition, "transition_done")
 	

--- a/addons/escoria-core/ui_library/tools/room_select/room_select.gd
+++ b/addons/escoria-core/ui_library/tools/room_select/room_select.gd
@@ -48,12 +48,14 @@ func _ready():
 
 # Switch to the selected room
 func _on_button_pressed():
+	escoria.globals_manager.set_global("BYPASS_LAST_SCENE", true, true)
 	var script = escoria.esc_compiler.compile([
 		":debug",
 		"change_scene %s" % _options_paths[_selected_id]
 	])
 	escoria.event_manager.interrupt_running_event()
 	escoria.event_manager.queue_event(script.events['debug'])
+	
 
 
 # A room was selected, store the selection

--- a/game/rooms/room01/esc/room01.esc
+++ b/game/rooms/room01/esc/room01.esc
@@ -4,9 +4,6 @@
 	# Set player look left
 	set_angle player 270
 	stop
-> [!eq ESC_LAST_SCENE room2]
-	teleport player player_start
-	stop
 
 
 

--- a/game/rooms/room02/esc/room02_bridge.esc
+++ b/game/rooms/room02/esc/room02_bridge.esc
@@ -26,10 +26,6 @@
 	#set_interactive r2_bridge false
 	stop
 	
-> [!last_scene]
-	teleport player player_start
-	stop
-
 
 :ready
 

--- a/game/rooms/room03/esc/room03_bridge.esc
+++ b/game/rooms/room03/esc/room03_bridge.esc
@@ -29,9 +29,6 @@
 	> [!r3_bridge_closed]
 		set_interactive r3_right_platform false
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 
 
 :ready

--- a/game/rooms/room04/esc/room04.esc
+++ b/game/rooms/room04/esc/room04.esc
@@ -9,7 +9,4 @@
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 

--- a/game/rooms/room05/esc/room05.esc
+++ b/game/rooms/room05/esc/room05.esc
@@ -23,10 +23,6 @@
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	set_angle player 90
-	stop
 
 
 #walk player r5_wrench

--- a/game/rooms/room06/esc/room06.esc
+++ b/game/rooms/room06/esc/room06.esc
@@ -9,9 +9,6 @@
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 
 #set_global i/r5_pen true
 #set_active r5_pen false

--- a/game/rooms/room07/esc/room07.esc
+++ b/game/rooms/room07/esc/room07.esc
@@ -16,8 +16,5 @@ set_state r7_button_zoom button_repaired true
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 
 

--- a/game/rooms/room08/esc/room08.esc
+++ b/game/rooms/room08/esc/room08.esc
@@ -13,7 +13,4 @@
 	# Set player look down
 	set_angle player 180
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 

--- a/game/rooms/room09/esc/room09.esc
+++ b/game/rooms/room09/esc/room09.esc
@@ -18,8 +18,5 @@
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 
 

--- a/game/rooms/room10/esc/room10.esc
+++ b/game/rooms/room10/esc/room10.esc
@@ -10,7 +10,4 @@
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 

--- a/game/rooms/room11/esc/room11.esc
+++ b/game/rooms/room11/esc/room11.esc
@@ -12,7 +12,4 @@ set_state _music off false
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 

--- a/game/rooms/room12/esc/room12.esc
+++ b/game/rooms/room12/esc/room12.esc
@@ -11,9 +11,6 @@
 	# Set player look left
 	set_angle player 270
 	stop
-> [!last_scene]
-	teleport player player_start
-	stop
 
 
 :ready

--- a/game/rooms/room12/room12.tscn
+++ b/game/rooms/room12/room12.tscn
@@ -90,4 +90,3 @@ position = Vector2( 340.052, 298.812 )
 position = Vector2( 542.824, 468.193 )
 script = ExtResource( 5 )
 global_id = "player_start"
-is_start_location = true

--- a/game/rooms/room13/room13.tscn
+++ b/game/rooms/room13/room13.tscn
@@ -32,8 +32,7 @@ camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
 margin_right = 92.0
 margin_bottom = 21.0
 custom_fonts/font = ExtResource( 3 )
-text = "ROOM 12
-"
+text = "ROOM 13"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/project.godot
+++ b/project.godot
@@ -690,7 +690,7 @@ debug/room_selector_room_dir="res://game/rooms"
 
 esc_show_debug_prompt={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777245,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777245,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 switch_action_verb={


### PR DESCRIPTION
Introducing BYPASS_LAST_ROOM global to allow changing scene without considering the previous room
Fixes godot-escoria/escoria-demo-game#1135