### PR TITLE
Fix crash when the player exits a room while talking

### DIFF
--- a/addons/escoria-core/ui_library/dialogs/floating_dialog_player.gd
+++ b/addons/escoria-core/ui_library/dialogs/floating_dialog_player.gd
@@ -88,7 +88,9 @@ func _on_dialog_line_typed(object, key):
 
 # Ending the dialog
 func _on_dialog_finished():
-	current_character.stop_talking()
+	# Make the speaking item animation stop talking, if it is still alive
+	if is_instance_valid(current_character) and current_character != null:
+		current_character.stop_talking()
 	emit_signal("dialog_line_finished")
 	escoria.dialog_player.is_speaking = false
 	queue_free()

--- a/game/rooms/room01/esc/trigger.esc
+++ b/game/rooms/room01/esc/trigger.esc
@@ -1,0 +1,5 @@
+:trigger_in
+
+
+:trigger_out
+say player "About to leave..."

--- a/game/rooms/room01/room01.tscn
+++ b/game/rooms/room01/room01.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://game/rooms/room01/walkable_area.tscn" type="PackedScene" id=1]
 [ext_resource path="res://game/rooms/room01/background.tscn" type="PackedScene" id=2]
 [ext_resource path="res://game/fonts/caslonantique.tres" type="DynamicFont" id=3]
 [ext_resource path="res://game/characters/mark/mark.tscn" type="PackedScene" id=4]
+[ext_resource path="res://addons/escoria-core/game/core-scripts/esc_item.gd" type="Script" id=5]
 [ext_resource path="res://addons/escoria-core/game/core-scripts/esc_room.gd" type="Script" id=6]
 [ext_resource path="res://addons/escoria-core/game/core-scripts/esc_location.gd" type="Script" id=7]
 [ext_resource path="res://game/rooms/room01/r_door.tscn" type="PackedScene" id=8]
@@ -90,6 +91,20 @@ __meta__ = {
 "_edit_use_anchors_": false,
 "_editor_description_": ""
 }
+
+[node name="trigger_talk" type="Area2D" parent="Hotspots"]
+pause_mode = 1
+script = ExtResource( 5 )
+global_id = "trigger_talk"
+esc_script = "res://game/rooms/room01/esc/trigger.esc"
+is_trigger = true
+is_interactive = false
+player_orients_on_arrival = false
+dialog_color = Color( 1, 1, 1, 1 )
+animations = null
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Hotspots/trigger_talk"]
+polygon = PoolVector2Array( 1150.17, 350.281, 1250.28, 457.068, 1174.19, 526.48, 1096.77, 348.947 )
 
 [node name="player_start" type="Position2D" parent="."]
 position = Vector2( 172.471, 434.487 )


### PR DESCRIPTION
Fixes godot-escoria/escoria-demo-game#1132
To demonstrate, a trigger was added in front of exit in room1