### PR TITLE
fix: Correctly get inventory objects registered in other rooms

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
@@ -296,6 +296,17 @@ func get_object(global_id: String, room: ESCRoom = null) -> ESCObject:
 			"Object with global id %s in room instance (%s, %s) not found."
 			% [global_id, room_key.room_global_id, room_key.room_instance_id]
 		)
+		if escoria.inventory_manager.inventory_has(global_id):
+			# item is in the inventory and may be registered to a different room
+			for single_room in room_objects:
+				# these are arrays of the objects still registered for each room
+				if single_room.objects.has(global_id):
+					escoria.logger.info(
+						self,
+						"Object with global id %s found in room instance (%s, %s) through the inventory."
+						% [global_id, room_key.room_global_id, room_key.room_instance_id]
+					)
+					return single_room.objects[global_id]
 		return null
 
 


### PR DESCRIPTION
This fixes https://github.com/godot-escoria/escoria-demo-game/issues/895

As I mentioned on Discord, when an object is added to the inventory it is added to an array for the room the player is currently in. When `get_object` got called, it would only look in the current room, skipping all possible inventory items from other rooms.

This fix gets around that, specifically for items that are registered in the inventory.

I'm opening this as a draft because I'm not 100% this is the entirely correct solution. (and on top of that, I'm not 100% I followed the contribution guidelines correctly)
A better approach could be to have a separate array for inventory items. I noticed it's not there, and I don't know the history of the reasoning why.
Alternatively, yet another approach could be to have a similar loop through the objects in the rooms, but to wrap that in a `func` in the inventory manager, to "hide" its implementation details from the object manager.