### PR TITLE
fix: forces the Godot IDE to show the applicable resource type to use…

### DIFF
--- a/addons/escoria-core/game/core-scripts/resources/esc_animationresource.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_animationresource.gd
@@ -9,22 +9,22 @@ class_name ESCAnimationResource
 ## start_angle must be between 0 and 360.[br]
 ## Angles 0 and 360 are the same and correspond to UP/NORTH, 90 is RIGHT/EAST,
 ## 180 is DOWN/SOUTH, 270 is LEFT/WEST etc.
-@export var dir_angles: Array = []: set = set_dir_angles
+@export var dir_angles: Array[ESCDirectionAngle] = []: set = set_dir_angles
 
 ## Array of animations for each direction, from UP to RIGHT_UP clockwise.[br]
 ## Each entry is [animation_name, scale]. The scale parameter can be set to -1 to
 ## mirror the animation.
-@export var directions: Array = []: set = set_directions
+@export var directions: Array[ESCAnimationName] = []: set = set_directions
 
 ## Array containing the idle animations for each direction (in the order defined
 ## by dir_angles).[br]
 ## The scale parameter can be set to -1 to mirror the animation.
-@export var idles: Array = []: set = set_idles
+@export var idles: Array[ESCAnimationName] = []: set = set_idles
 
 ## Array containing the speak animations for each direction (in the order defined
 ## by dir_angles).[br]
 ## The scale parameter can be set to -1 to mirror the animation.
-@export var speaks: Array = []: set = set_speaks
+@export var speaks: Array[ESCAnimationName] = []: set = set_speaks
 
 ## Sets the dir_angles property.[br]
 ## [br]
@@ -37,7 +37,7 @@ class_name ESCAnimationResource
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func set_dir_angles(p_dir_angles: Array) -> void:
+func set_dir_angles(p_dir_angles: Array[ESCDirectionAngle]) -> void:
 	dir_angles = p_dir_angles
 	emit_changed()
 
@@ -52,7 +52,7 @@ func set_dir_angles(p_dir_angles: Array) -> void:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func set_directions(p_set_directions: Array) -> void:
+func set_directions(p_set_directions: Array[ESCAnimationName]) -> void:
 	directions = p_set_directions
 	emit_changed()
 
@@ -67,7 +67,7 @@ func set_directions(p_set_directions: Array) -> void:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func set_idles(p_set_idles: Array) -> void:
+func set_idles(p_set_idles: Array[ESCAnimationName]) -> void:
 	idles = p_set_idles
 	emit_changed()
 
@@ -82,7 +82,7 @@ func set_idles(p_set_idles: Array) -> void:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func set_speaks(p_set_speaks: Array) -> void:
+func set_speaks(p_set_speaks: Array[ESCAnimationName]) -> void:
 	speaks = p_set_speaks
 	emit_changed()
 


### PR DESCRIPTION
… immediately instead of needing to wade through a ton of Godot classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type specifications for animation resource configuration to enhance code reliability and maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->