### PR TITLE
fix: checks inventory variable value

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_inventory_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_inventory_manager.gd
@@ -16,7 +16,9 @@ class_name ESCInventoryManager
 ## [br]
 ## Returns a `bool` value. (`bool`)
 func inventory_has(item: String) -> bool:
-	return escoria.globals_manager.has("i/%s" % item)
+	if not escoria.globals_manager.has("i/%s" % item):
+		return false
+	return escoria.globals_manager.get_global("i/%s" % item)
 
 
 ## Retrieves all inventory items.[br]


### PR DESCRIPTION
Adapts `.has` method from the inventory manager to use the value when it's present.
There are cases when an item is placed and taken many times.
In ashes: `in inventory`  uses this method.