### PR TITLE
chore: changes log level to debug when animation player is missing

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -672,12 +672,12 @@ func get_animation_player() -> Node:
 						child is AnimationPlayer:
 					player_node_path = child.get_path()
 		if player_node_path.is_empty():
-			ESCSafeLogging.log_warn(
+			ESCSafeLogging.log_debug(
 				self,
 				"Can not find animation_player or animated sprite for %s." % global_id
 			)
 		elif not has_node(player_node_path):
-			ESCSafeLogging.log_warn(
+			ESCSafeLogging.log_debug(
 				self,
 				"Can not find animation_player node at path %s for %s." % [player_node_path, global_id]
 			)


### PR DESCRIPTION
The idea is to remove the warning from the logs.
The majority of the items don't have animations... and it makes more difficult going through the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal logging levels for improved debugging efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->