### PR TITLE
fix: adds 'ambient volume' setting into Escoria settings

### DIFF
--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -446,6 +446,16 @@ func _set_escoria_sound_settings():
 	)
 
 	register_setting(
+		ESCProjectSettingsManager.AMBIENT_VOLUME,
+		1,
+		{
+			"type": TYPE_FLOAT,
+			"hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,1"
+		}
+	)
+
+	register_setting(
 		ESCProjectSettingsManager.SPEECH_VOLUME,
 		1,
 		{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ambient volume sound setting to project configuration, allowing users to adjust ambient sound levels independently of other audio channels. The setting ranges from 0 to 1 and complements existing master, music, and sound effects volume controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->