### PR TITLE
fix: combination bug didn't work + tooltip min height

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -659,6 +659,7 @@ func perform_inputevent_on_object(
 			# If object is in inventory make it current tool.
 			if escoria.inventory_manager.inventory_has(obj.global_id):
 				current_tool = obj
+			return
 		# If clicked object doesn't need a combination, then we simply run the action.
 		else:
 			event_to_queue = _get_event_to_queue(current_action, obj)

--- a/addons/escoria-core/game/core-scripts/esc_tooltip.gd
+++ b/addons/escoria-core/game/core-scripts/esc_tooltip.gd
@@ -34,7 +34,7 @@ var current_action: String
 var current_target: String
 
 ## Preposition: on, with...
-var current_prep: String = "with"
+var current_prep: String = "with "
 
 ## Target 2 item/hotspot
 var current_target2: String

--- a/addons/escoria-ui-keyboard-9verbs/game.tscn
+++ b/addons/escoria-ui-keyboard-9verbs/game.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://yv8r2xh0jvft" path="res://addons/escoria-ui-keyboard-9verbs/tooltip/action_target_tooltip.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://b5yss2p8c83cp" path="res://addons/escoria-ui-keyboard-9verbs/inventory/inventory_ui.tscn" id="2"]
-[ext_resource type="PackedScene" path="res://addons/escoria-ui-keyboard-9verbs/verbs_menu.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://c7fwywnj0glve" path="res://addons/escoria-ui-keyboard-9verbs/verbs_menu.tscn" id="3"]
 [ext_resource type="Script" uid="uid://dfl7khtlretr7" path="res://addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd" id="4"]
 [ext_resource type="Script" uid="uid://bb1iia3lec7ja" path="res://addons/escoria-ui-keyboard-9verbs/game.gd" id="5"]
 [ext_resource type="PackedScene" uid="uid://dmw5gicuenj53" path="res://addons/escoria-core/game/scenes/camera_player/camera.tscn" id="6"]
@@ -55,6 +55,7 @@ layout_mode = 2
 theme_override_constants/margin_top = 10
 
 [node name="tooltip" parent="ui/Control/panel_down/VBoxContainer/MarginContainer" instance=ExtResource("1")]
+custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 text = "Test"
 color = Color(1, 1, 1, 1)

--- a/addons/escoria-ui-keyboard-9verbs/tooltip/tooltip_action_target.gd
+++ b/addons/escoria-ui-keyboard-9verbs/tooltip/tooltip_action_target.gd
@@ -11,10 +11,10 @@ func update_tooltip_text():
 
 	if waiting_for_target2 and current_target2.is_empty():
 		current_prep = prepositions.get(current_action, current_prep)
-		text += "\t" + current_prep
+		text += "\t" + current_prep + " \t"
 
 	if !current_target2.is_empty():
-		text += "\t" + current_prep + "\t" + current_target2
+		text += "\t" + current_prep + " \t" + current_target2
 
 	text += "[/color]"
 	text += "[/center]"


### PR DESCRIPTION
This PR fixes an issue detected when performing a combination (use inventory item).
Also, includes a small fix with minimum height of the tooltip label