### PR TITLE
chore(release): prepare v4.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.0-beta.2](https://github.com/godot-escoria/escoria-demo-game/compare/v4.0.0-beta.1...v4.0.0-beta.2) (2026-03-14)
+
+### CI
+
+* omit GDUnit4 addon (when merged in) ([77487a1](https://github.com/godot-escoria/escoria-demo-game/commit/77487a1fee094d5191ab1b79ac0efde9b9998741))
+
 ## [4.0.0-beta.1](https://github.com/godot-escoria/escoria-demo-game/compare/v4.0.0-alpha.316...v4.0.0-beta.1) (2026-03-08)
 
 ### Bug Fixes


### PR DESCRIPTION
Prepare release PR for `v4.0.0-beta.2`.

Once merged, the publish workflow will create the tag and GitHub Release automatically.

## [4.0.0-beta.2](https://github.com/godot-escoria/escoria-demo-game/compare/v4.0.0-beta.1...v4.0.0-beta.2) (2026-03-14)

### CI

* omit GDUnit4 addon (when merged in) ([77487a1](https://github.com/godot-escoria/escoria-demo-game/commit/77487a1fee094d5191ab1b79ac0efde9b9998741))



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry for version 4.0.0-beta.2, dated March 14, 2026.
  * Documented a continuous integration note regarding the omission of the GDUnit4 addon during the merge process.
  * No other changelog entries or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->