### PR TITLE
fix(input): ignore non-actionable trigger enter and exit events

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -1,11 +1,7 @@
 ## Manages actions currently being carried out.
 ## @MANAGER
-extends Resource
 class_name ESCActionManager
-
-
-## ESCPlayer resource
-const ESCPlayer = preload("res://addons/escoria-core/game/core-scripts/esc_player.gd")
+extends Resource
 
 
 ## The current action verb was changed.[br]
@@ -39,7 +35,7 @@ signal action_input_state_changed
 ## (I) -> AWAITING_VERB_OR_ITEM -> AWAITING_ITEM -> AWAITING_TARGET_ITEM -> COMPLETED -> (E)[br]
 ## or[br]
 ## (I) -> AWAITING_VERB_OR_ITEM -> AWAITING_VERB -> AWAITING_VERB_CONFIRMATION -> COMPLETED -> (E)
-enum ACTION_INPUT_STATE {
+enum ActionInputState {
 	AWAITING_VERB_OR_ITEM, ## Initial state
 	AWAITING_ITEM,        ## After initial state, verb is defined
 	AWAITING_TARGET_ITEM, ## Item defined requires combine, waiting for target
@@ -65,6 +61,9 @@ enum ACTION {
 
 # Basic required internal actions
 
+## ESCPlayer resource
+const ESCPlayer = preload("res://addons/escoria-core/game/core-scripts/esc_player.gd")
+
 ## Action (event) triggered when a character has reached a destination.
 const ACTION_ARRIVED = "arrived"
 
@@ -85,7 +84,7 @@ var current_tool: ESCObject
 var current_target: ESCObject
 
 ## Current action input state.
-var action_state = ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM:
+var action_state = ActionInputState.AWAITING_VERB_OR_ITEM:
 	set = set_action_input_state
 
 
@@ -277,10 +276,10 @@ func set_current_action(action: String) -> void:
 
 	current_action = action
 
-	if action_state == ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM:
-		set_action_input_state(ACTION_INPUT_STATE.AWAITING_ITEM)
-	elif action_state == ACTION_INPUT_STATE.AWAITING_VERB:
-		set_action_input_state(ACTION_INPUT_STATE.AWAITING_VERB_CONFIRMATION)
+	if action_state == ActionInputState.AWAITING_VERB_OR_ITEM:
+		set_action_input_state(ActionInputState.AWAITING_ITEM)
+	elif action_state == ActionInputState.AWAITING_VERB:
+		set_action_input_state(ActionInputState.AWAITING_VERB_CONFIRMATION)
 
 	action_changed.emit()
 
@@ -296,7 +295,7 @@ func set_current_action(action: String) -> void:
 ## Returns nothing.
 func clear_current_action() -> void:
 	set_current_action("")
-	set_action_input_state(ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM)
+	set_action_input_state(ActionInputState.AWAITING_VERB_OR_ITEM)
 	action_changed.emit()
 
 
@@ -312,10 +311,10 @@ func clear_current_action() -> void:
 func clear_current_tool() -> void:
 	current_tool = null
 	current_target = null
-	if action_state == ACTION_INPUT_STATE.AWAITING_VERB:
-		set_action_input_state(ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM)
-	elif action_state == ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
-		set_action_input_state(ACTION_INPUT_STATE.AWAITING_ITEM)
+	if action_state == ActionInputState.AWAITING_VERB:
+		set_action_input_state(ActionInputState.AWAITING_VERB_OR_ITEM)
+	elif action_state == ActionInputState.AWAITING_TARGET_ITEM:
+		set_action_input_state(ActionInputState.AWAITING_ITEM)
 
 
 ## Checks if the specified action is valid and returns the associated event; otherwise, we see if there's a "fallback" event and use that if necessary and, if not, we return no event as there's nothing to do. or there's a reason not to run an event.[br]
@@ -491,7 +490,7 @@ func _check_target_has_proper_action(target: ESCObject, action: String) -> bool:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func _has_event_with_target(events_dict: Dictionary, event_name: String, event_target: String):
+func _has_event_with_target(events_dict: Dictionary, event_name: String, _event_target: String):
 	var event = events_dict.get(event_name)
 	if event == null:
 		return false
@@ -596,29 +595,8 @@ func perform_inputevent_on_object(
 	event: InputEvent,
 	default_action: bool = false
 ) -> void:
-	"""
-	This algorithm:
-	- validates the requested action
-	- grabs the corresponding event for the action, if available
-	- makes the player move to the clicked object location, if needed
-	(if it is located in the room for example) and wait for reaching.
-	- when reached, performs an action depending on current defined action
-		* no current action defined: do nothing else
-		* current action defined:
-			* item requires no combination: perform the current action
-			  on the item
-			* item requires combination: check the status of the combination
-			  A combination requires 3 elements to fulfill:
-				1/ a verb action
-				2/ a first "tool" (item to use)
-				3/ a second "tool" (item to use ON)
-			  Whatever the user inputs to fulfill the combination (this is
-			  determined by gamedev in his game.gd script)
-				- combination not fulfilled: no not perform until fulfilled
-				- combination fulfilled: perform the combination.
-		* else do nothing, except if default_action is requested.
-		  In this case, perform the default_action on the item.
-	"""
+	# This algorithm validates the requested action, moves the player if needed,
+	# and resolves the current action state against the clicked object.
 
 	escoria.logger.info(
 		self,
@@ -646,14 +624,14 @@ func perform_inputevent_on_object(
 		current_target = obj
 
 	# Update the action input state
-	if action_state == ACTION_INPUT_STATE.AWAITING_TARGET_ITEM and current_target:
-		set_action_input_state(ACTION_INPUT_STATE.COMPLETED)
-	elif action_state == ACTION_INPUT_STATE.AWAITING_ITEM and \
+	if action_state == ActionInputState.AWAITING_TARGET_ITEM and current_target:
+		set_action_input_state(ActionInputState.COMPLETED)
+	elif action_state == ActionInputState.AWAITING_ITEM and \
 			not need_combine:
-		set_action_input_state(ACTION_INPUT_STATE.COMPLETED)
-	elif action_state == ACTION_INPUT_STATE.AWAITING_ITEM and \
+		set_action_input_state(ActionInputState.COMPLETED)
+	elif action_state == ActionInputState.AWAITING_ITEM and \
 			need_combine and not tool_just_set:
-		set_action_input_state(ACTION_INPUT_STATE.AWAITING_TARGET_ITEM)
+		set_action_input_state(ActionInputState.AWAITING_TARGET_ITEM)
 
 	var event_to_queue: ESCGrammarStmts.Event = null
 
@@ -673,7 +651,7 @@ func perform_inputevent_on_object(
 			event_to_queue = _get_event_to_queue(current_action, current_tool, current_target)
 		# If clicked object needs a combination then we need to wait for the target.
 		elif need_combine:
-			set_action_input_state(ACTION_INPUT_STATE.AWAITING_TARGET_ITEM)
+			set_action_input_state(ActionInputState.AWAITING_TARGET_ITEM)
 			# If object is in inventory make it current tool.
 			if escoria.inventory_manager.inventory_has(obj.global_id):
 				current_tool = obj

--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -172,6 +172,7 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 				var trigger_id = params[0]
 				var object_id = params[1]
 				var trigger_in_verb = params[2]
+				var trigger_object := escoria.object_manager.get_object(trigger_id)
 				escoria.logger.info(
 					self,
 					"trigger_in on trigger %s activated by %s." % [
@@ -179,9 +180,17 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 						object_id
 					]
 				)
-				if trigger_in_verb in escoria.object_manager.get_object(trigger_id).events:
+
+				if not _is_object_actionable(trigger_object):
+					escoria.logger.info(
+						self,
+						"Trigger %s is not actionable. Skipping trigger_in." % trigger_id
+					)
+					return
+
+				if trigger_in_verb in trigger_object.events:
 					escoria.event_manager.queue_event(
-						escoria.object_manager.get_object(trigger_id).events[
+						trigger_object.events[
 							trigger_in_verb
 						]
 					)
@@ -195,6 +204,7 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 				var trigger_id = params[0]
 				var object_id = params[1]
 				var trigger_out_verb = params[2]
+				var trigger_object := escoria.object_manager.get_object(trigger_id)
 				escoria.logger.info(
 					self,
 					"trigger_out on trigger %s activated by %s." % [
@@ -202,9 +212,17 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 						object_id
 					]
 				)
-				if trigger_out_verb in escoria.object_manager.get_object(trigger_id).events:
+
+				if not _is_object_actionable(trigger_object):
+					escoria.logger.info(
+						self,
+						"Trigger %s is not actionable. Skipping trigger_out." % trigger_id
+					)
+					return
+
+				if trigger_out_verb in trigger_object.events:
 					escoria.event_manager.queue_event(
-						escoria.object_manager.get_object(trigger_id).events[
+						trigger_object.events[
 							trigger_out_verb
 						]
 					)

--- a/addons/escoria-core/game/esc_inputs_manager.gd
+++ b/addons/escoria-core/game/esc_inputs_manager.gd
@@ -2,8 +2,8 @@
 ##
 ## Catches, handles and distributes input events for the game.
 ## @MANAGER
-extends Resource
 class_name ESCInputsManager
+extends Resource
 
 
 ## Valid input flags[br]
@@ -77,7 +77,7 @@ func _init():
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func _on_event_finished(return_code: int, event_name: String):
+func _on_event_finished(_return_code: int, _event_name: String):
 	if _hovered_element == null:
 		hotspot_focused = ""
 
@@ -162,8 +162,8 @@ func register_custom_input_handler(callback) -> void:
 func try_custom_input_handler(event: InputEvent, is_default_state: bool) -> bool:
 	if custom_input_handler:
 		return custom_input_handler.call(event, is_default_state)
-	else:
-		return false
+
+	return false
 
 ## Callback called by hover stack content change.[br]
 ## [br]
@@ -210,8 +210,7 @@ func set_hovered_node(item: ESCItem) -> bool:
 		_hovered_element.mouse_entered()
 		return true
 	# Else, the tested item is currently on top of hover stack, then do nothing
-	else:
-		return false
+	return false
 
 
 ## Unsets the hovered node.[br]
@@ -506,10 +505,10 @@ func on_item_non_interactive(item: ESCItem) -> void:
 
 		if hover_stack.is_empty():
 			return
-		else:
-			var new_item = hover_stack.get_top_item()
-			escoria.action_manager.set_action_input_state(ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM)
-			new_item.mouse_entered()
+
+		var new_item = hover_stack.get_top_item()
+		escoria.action_manager.set_action_input_state(ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM)
+		new_item.mouse_entered()
 
 
 # An Escoria item was clicked with the LMB


### PR DESCRIPTION
Fixes #803 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and validation of trigger actions with clearer logging when triggers target non-actionable items.
  * Prevented redundant trigger processing and reduced errors from missing trigger events.
  * Safer hover and input handling to avoid incorrect or stale interactions.

* **Refactor**
  * Simplified and standardized internal input/action handling for more consistent behavior and modest performance gains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->