### PR TITLE
fix(commands): reject negative set_speed values

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/set_speed.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_speed.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetSpeedCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_speed.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_speed.gd
@@ -49,6 +49,13 @@ func validate(arguments: Array):
 	if not escoria.object_manager.has(arguments[0]):
 		raise_invalid_object_error(self, arguments[0])
 		return false
+
+	if arguments[1] < 0:
+		raise_error(
+			self,
+			"Invalid speed. Speed cannot be negative (%d)." % arguments[1]
+		)
+		return false
 	return true
 
 ## Runs the command.[br]

--- a/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
+++ b/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
@@ -1311,6 +1311,38 @@ func test_set_animations_updates_persisted_player_resource_on_repeat_calls() -> 
 	room.free()
 
 
+func test_set_speed_rejects_negative_values_but_accepts_zero() -> void:
+	var room := ESCRoom.new()
+	room.global_id = "test_room_set_speed_contract"
+	escoria.object_manager.set_current_room(room)
+
+	var player := load("res://game/characters/mark/mark.tscn").instantiate() as ESCPlayer
+	player.global_id = "player"
+	escoria.object_manager.register_object(
+		ESCObject.new(player.global_id, player),
+		room,
+		true,
+		false
+	)
+
+	var command := SetSpeedCommand.new()
+	var initial_speed := player.speed
+
+	assert_bool(command.validate([player.global_id, -1])).is_false()
+	assert_int(player.speed).is_equal(initial_speed)
+
+	assert_bool(command.validate([player.global_id, 0])).is_true()
+	assert_int(command.run([player.global_id, 0])).is_equal(ESCExecution.RC_OK)
+	assert_int(player.speed).is_equal(0)
+
+	var room_key := ESCRoomObjectsKey.new()
+	room_key.room_global_id = room.global_id
+	room_key.room_instance_id = room.get_instance_id()
+	escoria.object_manager.unregister_object_by_global_id(player.global_id, room_key)
+	player.free()
+	room.free()
+
+
 func test_trigger_actions_select_targeted_events_for_activating_object() -> void:
 	var script_object := _compile_fixture_script("trigger_targeted_events_use_object_id.esc")
 	var room := ESCRoom.new()

--- a/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
+++ b/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
@@ -5,6 +5,8 @@ extends GdUnitTestSuite
 @warning_ignore("unused_parameter")
 @warning_ignore("return_value_discarded")
 
+const MARK_SCENE := preload("res://game/characters/mark/mark.tscn")
+
 var _terminate_on_errors_before: bool
 var _command_directories_before: PackedStringArray
 var _dialog_player_before
@@ -1271,7 +1273,7 @@ func test_set_animations_updates_persisted_player_resource_on_repeat_calls() -> 
 	room.global_id = "test_room_issue_1226"
 	escoria.object_manager.set_current_room(room)
 
-	var player := load("res://game/characters/mark/mark.tscn").instantiate() as ESCPlayer
+	var player := MARK_SCENE.instantiate() as ESCPlayer
 	player.global_id = "player"
 	escoria.object_manager.register_object(
 		ESCObject.new(player.global_id, player),
@@ -1316,7 +1318,7 @@ func test_set_speed_rejects_negative_values_but_accepts_zero() -> void:
 	room.global_id = "test_room_set_speed_contract"
 	escoria.object_manager.set_current_room(room)
 
-	var player := load("res://game/characters/mark/mark.tscn").instantiate() as ESCPlayer
+	var player := MARK_SCENE.instantiate() as ESCPlayer
 	player.global_id = "player"
 	escoria.object_manager.register_object(
 		ESCObject.new(player.global_id, player),


### PR DESCRIPTION
Fixes #929 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now rejects negative speed values and accepts zero, preventing invalid player speeds and ensuring correct application of speed changes.

* **Tests**
  * Added/updated tests to confirm negative speeds are rejected, zero is accepted, command execution updates player speed as expected, and test setup has been streamlined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->