### PR TITLE
feat: finish full implementation of dialog avatar, default timeout, and default dialog option

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter.gd
@@ -474,8 +474,10 @@ func visit_dialog_stmt(stmt: ESCGrammarStmts.Dialog):
 	var dialog: ESCDialog = ESCDialog.new()
 	var rc = ESCExecution.RC_OK
 	var dialog_args := stmt.get_args()
+	var dialog_options := stmt.get_options()
 
 	_dialog_depth += 1
+	dialog.authored_options_count = dialog_options.size()
 
 	if dialog_args.size() > 0:
 		var avatar = await _evaluate(dialog_args[0])
@@ -535,9 +537,11 @@ func visit_dialog_stmt(stmt: ESCGrammarStmts.Dialog):
 	while true:
 		dialog.options = []
 
-		for dialog_option in stmt.get_options():
+		for index in range(dialog_options.size()):
+			var dialog_option = dialog_options[index]
 			var option: ESCDialogOption = ESCDialogOption.new()
 			option.source_option = dialog_option
+			option.source_option_index = index + 1
 			option.translation_key = dialog_option.get_translation_key()
 			option.option = await _evaluate(dialog_option.get_option())
 

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
@@ -12,6 +12,9 @@ var timeout: int = 0
 ## The dialog option to select when timeout is reached.
 var timeout_option: int = 0
 
+## Total number of options authored in this dialog, including currently hidden options.
+var authored_options_count: int = 0
+
 ## A list of `ESCDialogOption`s.
 var options: Array
 
@@ -32,7 +35,11 @@ func is_valid() -> bool:
 			"Avatar scene not found: %s." % self.avatar
 		)
 		return false
-	if self.timeout_option > self.options.size() \
+	var option_count := self.authored_options_count
+	if option_count == 0:
+		option_count = self.options.size()
+
+	if self.timeout_option > option_count \
 			or self.timeout_option < 0:
 		escoria.logger.error(
 			self,
@@ -41,6 +48,33 @@ func is_valid() -> bool:
 		return false
 
 	return true
+
+
+## Returns the currently visible option configured as the timeout default, if any.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## Returns the currently visible timeout option as an `ESCDialogOption`, or `null` if the configured option is not visible.
+func get_timeout_option() -> ESCDialogOption:
+	var has_source_option_indexes := false
+
+	for option in self.options:
+		if option.source_option_index > 0:
+			has_source_option_indexes = true
+
+		if option.source_option_index == self.timeout_option:
+			return option
+
+	if not has_source_option_indexes \
+			and self.timeout_option > 0 \
+			and self.timeout_option <= self.options.size():
+		return self.options[self.timeout_option - 1]
+
+	return null
 
 
 ## Run this dialog. TODO: Although this method overrides its parent version, the return type here does NOT match the parent's signature. Consider either changing the parent's return type to be a `Variant`, or doing something to ensure greater consistency.[br]

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
@@ -1,6 +1,6 @@
 ## Represents a dialog in Escoria.
-extends ESCStatement
 class_name ESCDialog
+extends ESCStatement
 
 
 ## Avatar used in the dialog, if any.

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog_option.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog_option.gd
@@ -15,6 +15,9 @@ var translation_key: String = ""
 ## Maps back to the parsed source option.
 var source_option
 
+## One-based index of this option in its authored dialog block.
+var source_option_index: int = -1
+
 ## Whether this option is valid.
 var _is_valid: bool:
 	set = set_is_valid,

--- a/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
+++ b/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
@@ -6,6 +6,7 @@ extends GdUnitTestSuite
 @warning_ignore("return_value_discarded")
 
 const MARK_SCENE := preload("res://game/characters/mark/mark.tscn")
+const SIMPLE_CHOOSER_SCENE := preload("res://addons/escoria-dialog-simple/chooser/simple.tscn")
 
 var _terminate_on_errors_before: bool
 var _command_directories_before: PackedStringArray
@@ -1635,7 +1636,7 @@ func test_simple_chooser_does_not_start_timer_when_timeout_default_is_hidden() -
 		_make_dialog_option("Visible option", 2),
 	]
 
-	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	var chooser = SIMPLE_CHOOSER_SCENE.instantiate()
 	add_child(chooser)
 	chooser.set_dialog(dialog)
 	chooser.show_chooser()
@@ -1656,7 +1657,7 @@ func test_simple_chooser_starts_timer_when_timeout_default_is_visible() -> void:
 		_make_dialog_option("Second option", 2),
 	]
 
-	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	var chooser = SIMPLE_CHOOSER_SCENE.instantiate()
 	add_child(chooser)
 	chooser.set_dialog(dialog)
 	chooser.show_chooser()

--- a/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
+++ b/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
@@ -25,17 +25,24 @@ class DialogPlayerDouble extends ESCDialogPlayer:
 	func start_dialog_choices(dialog: ESCDialog, _type: String = "simple"):
 		var option_keys: Array = []
 		var option_texts: Array = []
+		var option_source_indexes: Array = []
 		for option in dialog.options:
 			option_keys.append(option.translation_key)
 			option_texts.append(option.option)
+			option_source_indexes.append(option.source_option_index)
+
+		var timeout_option := dialog.get_timeout_option()
 
 		_dialogs_started.append({
 			"avatar": dialog.avatar,
 			"timeout": dialog.timeout,
 			"timeout_option": dialog.timeout_option,
+			"authored_options_count": dialog.authored_options_count,
+			"visible_timeout_option": timeout_option.option if timeout_option else null,
 			"options_size": dialog.options.size(),
 			"option_keys": option_keys,
-			"option_texts": option_texts
+			"option_texts": option_texts,
+			"option_source_indexes": option_source_indexes
 		})
 
 		# Mirror the real dialog player closely enough for interpreter tests:
@@ -1555,9 +1562,108 @@ func test_dialog_start_args_are_passed_to_runtime_dialog() -> void:
 	assert_str(started_dialogs[0]["avatar"]).is_equal("res://game/dialog_avatars/player.tres")
 	assert_int(started_dialogs[0]["timeout"]).is_equal(5)
 	assert_int(started_dialogs[0]["timeout_option"]).is_equal(2)
+	assert_int(started_dialogs[0]["authored_options_count"]).is_equal(2)
 	assert_int(started_dialogs[0]["options_size"]).is_equal(2)
+	assert_str(started_dialogs[0]["visible_timeout_option"]).is_equal("Second option")
+	assert_array(started_dialogs[0]["option_source_indexes"]).contains_exactly([1, 2])
 
 	_cleanup_dialog_test(interpreter, dialog_player)
+
+
+func test_dialog_timeout_option_uses_authored_index_after_filtering() -> void:
+	var script_object := _compile_fixture_script("dialog_timeout_visible_authored_default_after_filtering.esc")
+	var dialog_player := DialogPlayerDouble.new([1])
+	escoria.set("dialog_player", dialog_player)
+	var interpreter := ESCInterpreter.new(ESCCompiler.load_commands(), {})
+	var resolver := ESCResolver.new(interpreter)
+	var event: ESCGrammarStmts.Event = script_object.get_event_with_target("talk")
+
+	assert_object(event).is_not_null()
+
+	resolver.resolve(event)
+
+	await interpreter.interpret(event)
+	assert_int(dialog_player.get_choices_consumed()).is_equal(1)
+
+	var started_dialogs := dialog_player.get_dialogs_started()
+	assert_int(started_dialogs.size()).is_equal(1)
+	assert_int(started_dialogs[0]["timeout"]).is_equal(5)
+	assert_int(started_dialogs[0]["timeout_option"]).is_equal(3)
+	assert_int(started_dialogs[0]["authored_options_count"]).is_equal(3)
+	assert_int(started_dialogs[0]["options_size"]).is_equal(2)
+	assert_array(started_dialogs[0]["option_source_indexes"]).contains_exactly([2, 3])
+	assert_array(started_dialogs[0]["option_texts"]).contains_exactly(["Second option", "Third option"])
+	assert_str(started_dialogs[0]["visible_timeout_option"]).is_equal("Third option")
+
+	_cleanup_dialog_test(interpreter, dialog_player)
+
+
+func test_dialog_timeout_option_hidden_after_filtering_is_not_available() -> void:
+	var script_object := _compile_fixture_script("dialog_timeout_hidden_authored_default_after_filtering.esc")
+	var dialog_player := DialogPlayerDouble.new([0])
+	escoria.set("dialog_player", dialog_player)
+	var interpreter := ESCInterpreter.new(ESCCompiler.load_commands(), {})
+	var resolver := ESCResolver.new(interpreter)
+	var event: ESCGrammarStmts.Event = script_object.get_event_with_target("talk")
+
+	assert_object(event).is_not_null()
+
+	resolver.resolve(event)
+
+	await interpreter.interpret(event)
+	assert_int(dialog_player.get_choices_consumed()).is_equal(1)
+
+	var started_dialogs := dialog_player.get_dialogs_started()
+	assert_int(started_dialogs.size()).is_equal(1)
+	assert_int(started_dialogs[0]["timeout"]).is_equal(5)
+	assert_int(started_dialogs[0]["timeout_option"]).is_equal(1)
+	assert_int(started_dialogs[0]["authored_options_count"]).is_equal(3)
+	assert_int(started_dialogs[0]["options_size"]).is_equal(2)
+	assert_array(started_dialogs[0]["option_source_indexes"]).contains_exactly([2, 3])
+	assert_array(started_dialogs[0]["option_texts"]).contains_exactly(["Second option", "Third option"])
+	assert_object(started_dialogs[0]["visible_timeout_option"]).is_null()
+
+	_cleanup_dialog_test(interpreter, dialog_player)
+
+
+func test_simple_chooser_does_not_start_timer_when_timeout_default_is_hidden() -> void:
+	var dialog := ESCDialog.new()
+	dialog.timeout = 5
+	dialog.timeout_option = 1
+	dialog.authored_options_count = 2
+	dialog.options = [
+		_make_dialog_option("Visible option", 2),
+	]
+
+	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	add_child(chooser)
+	chooser.set_dialog(dialog)
+	chooser.show_chooser()
+
+	assert_bool(chooser.get_node("Timer").is_stopped()).is_true()
+	assert_float(chooser.get_node("TimerProgress").value).is_equal(0.0)
+
+	chooser.queue_free()
+
+
+func test_simple_chooser_starts_timer_when_timeout_default_is_visible() -> void:
+	var dialog := ESCDialog.new()
+	dialog.timeout = 5
+	dialog.timeout_option = 2
+	dialog.authored_options_count = 2
+	dialog.options = [
+		_make_dialog_option("First option", 1),
+		_make_dialog_option("Second option", 2),
+	]
+
+	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	add_child(chooser)
+	chooser.set_dialog(dialog)
+	chooser.show_chooser()
+
+	assert_bool(chooser.get_node("Timer").is_stopped()).is_false()
+
+	chooser.queue_free()
 
 
 func test_dialog_start_invalid_avatar_type_returns_error() -> void:
@@ -1762,3 +1868,11 @@ func _compile_fixture_script(name: String) -> ESCScript:
 
 func _fixture_path(name: String) -> String:
 	return "res://addons/escoria-core/testing/ashes/interpreter/fixtures/%s" % name
+
+
+func _make_dialog_option(text: String, source_option_index: int) -> ESCDialogOption:
+	var option := ESCDialogOption.new()
+	option.option = text
+	option.source_option_index = source_option_index
+	option.set_is_valid(true)
+	return option

--- a/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
+++ b/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
@@ -6,6 +6,7 @@ extends GdUnitTestSuite
 @warning_ignore("return_value_discarded")
 
 const MARK_SCENE := preload("res://game/characters/mark/mark.tscn")
+const SIMPLE_CHOOSER_SCENE := preload("res://addons/escoria-dialog-simple/chooser/simple.tscn")
 
 var _terminate_on_errors_before: bool
 var _command_directories_before: PackedStringArray
@@ -1550,7 +1551,7 @@ func test_simple_chooser_does_not_start_timer_when_timeout_default_is_hidden() -
 		_make_dialog_option("Visible option", 2),
 	]
 
-	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	var chooser = SIMPLE_CHOOSER_SCENE.instantiate()
 	add_child(chooser)
 	chooser.set_dialog(dialog)
 	chooser.show_chooser()
@@ -1571,7 +1572,7 @@ func test_simple_chooser_starts_timer_when_timeout_default_is_visible() -> void:
 		_make_dialog_option("Second option", 2),
 	]
 
-	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	var chooser = SIMPLE_CHOOSER_SCENE.instantiate()
 	add_child(chooser)
 	chooser.set_dialog(dialog)
 	chooser.show_chooser()

--- a/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
+++ b/addons/escoria-core/testing/ashes/interpreter/esc_interpreter_test.gd
@@ -25,17 +25,24 @@ class DialogPlayerDouble extends ESCDialogPlayer:
 	func start_dialog_choices(dialog: ESCDialog, _type: String = "simple"):
 		var option_keys: Array = []
 		var option_texts: Array = []
+		var option_source_indexes: Array = []
 		for option in dialog.options:
 			option_keys.append(option.translation_key)
 			option_texts.append(option.option)
+			option_source_indexes.append(option.source_option_index)
+
+		var timeout_option := dialog.get_timeout_option()
 
 		_dialogs_started.append({
 			"avatar": dialog.avatar,
 			"timeout": dialog.timeout,
 			"timeout_option": dialog.timeout_option,
+			"authored_options_count": dialog.authored_options_count,
+			"visible_timeout_option": timeout_option.option if timeout_option else null,
 			"options_size": dialog.options.size(),
 			"option_keys": option_keys,
-			"option_texts": option_texts
+			"option_texts": option_texts,
+			"option_source_indexes": option_source_indexes
 		})
 
 		# Mirror the real dialog player closely enough for interpreter tests:
@@ -1470,9 +1477,108 @@ func test_dialog_start_args_are_passed_to_runtime_dialog() -> void:
 	assert_str(started_dialogs[0]["avatar"]).is_equal("res://game/dialog_avatars/player.tres")
 	assert_int(started_dialogs[0]["timeout"]).is_equal(5)
 	assert_int(started_dialogs[0]["timeout_option"]).is_equal(2)
+	assert_int(started_dialogs[0]["authored_options_count"]).is_equal(2)
 	assert_int(started_dialogs[0]["options_size"]).is_equal(2)
+	assert_str(started_dialogs[0]["visible_timeout_option"]).is_equal("Second option")
+	assert_array(started_dialogs[0]["option_source_indexes"]).contains_exactly([1, 2])
 
 	_cleanup_dialog_test(interpreter, dialog_player)
+
+
+func test_dialog_timeout_option_uses_authored_index_after_filtering() -> void:
+	var script_object := _compile_fixture_script("dialog_timeout_visible_authored_default_after_filtering.esc")
+	var dialog_player := DialogPlayerDouble.new([1])
+	escoria.set("dialog_player", dialog_player)
+	var interpreter := ESCInterpreter.new(ESCCompiler.load_commands(), {})
+	var resolver := ESCResolver.new(interpreter)
+	var event: ESCGrammarStmts.Event = script_object.get_event_with_target("talk")
+
+	assert_object(event).is_not_null()
+
+	resolver.resolve(event)
+
+	await interpreter.interpret(event)
+	assert_int(dialog_player.get_choices_consumed()).is_equal(1)
+
+	var started_dialogs := dialog_player.get_dialogs_started()
+	assert_int(started_dialogs.size()).is_equal(1)
+	assert_int(started_dialogs[0]["timeout"]).is_equal(5)
+	assert_int(started_dialogs[0]["timeout_option"]).is_equal(3)
+	assert_int(started_dialogs[0]["authored_options_count"]).is_equal(3)
+	assert_int(started_dialogs[0]["options_size"]).is_equal(2)
+	assert_array(started_dialogs[0]["option_source_indexes"]).contains_exactly([2, 3])
+	assert_array(started_dialogs[0]["option_texts"]).contains_exactly(["Second option", "Third option"])
+	assert_str(started_dialogs[0]["visible_timeout_option"]).is_equal("Third option")
+
+	_cleanup_dialog_test(interpreter, dialog_player)
+
+
+func test_dialog_timeout_option_hidden_after_filtering_is_not_available() -> void:
+	var script_object := _compile_fixture_script("dialog_timeout_hidden_authored_default_after_filtering.esc")
+	var dialog_player := DialogPlayerDouble.new([0])
+	escoria.set("dialog_player", dialog_player)
+	var interpreter := ESCInterpreter.new(ESCCompiler.load_commands(), {})
+	var resolver := ESCResolver.new(interpreter)
+	var event: ESCGrammarStmts.Event = script_object.get_event_with_target("talk")
+
+	assert_object(event).is_not_null()
+
+	resolver.resolve(event)
+
+	await interpreter.interpret(event)
+	assert_int(dialog_player.get_choices_consumed()).is_equal(1)
+
+	var started_dialogs := dialog_player.get_dialogs_started()
+	assert_int(started_dialogs.size()).is_equal(1)
+	assert_int(started_dialogs[0]["timeout"]).is_equal(5)
+	assert_int(started_dialogs[0]["timeout_option"]).is_equal(1)
+	assert_int(started_dialogs[0]["authored_options_count"]).is_equal(3)
+	assert_int(started_dialogs[0]["options_size"]).is_equal(2)
+	assert_array(started_dialogs[0]["option_source_indexes"]).contains_exactly([2, 3])
+	assert_array(started_dialogs[0]["option_texts"]).contains_exactly(["Second option", "Third option"])
+	assert_object(started_dialogs[0]["visible_timeout_option"]).is_null()
+
+	_cleanup_dialog_test(interpreter, dialog_player)
+
+
+func test_simple_chooser_does_not_start_timer_when_timeout_default_is_hidden() -> void:
+	var dialog := ESCDialog.new()
+	dialog.timeout = 5
+	dialog.timeout_option = 1
+	dialog.authored_options_count = 2
+	dialog.options = [
+		_make_dialog_option("Visible option", 2),
+	]
+
+	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	add_child(chooser)
+	chooser.set_dialog(dialog)
+	chooser.show_chooser()
+
+	assert_bool(chooser.get_node("Timer").is_stopped()).is_true()
+	assert_float(chooser.get_node("TimerProgress").value).is_equal(0.0)
+
+	chooser.queue_free()
+
+
+func test_simple_chooser_starts_timer_when_timeout_default_is_visible() -> void:
+	var dialog := ESCDialog.new()
+	dialog.timeout = 5
+	dialog.timeout_option = 2
+	dialog.authored_options_count = 2
+	dialog.options = [
+		_make_dialog_option("First option", 1),
+		_make_dialog_option("Second option", 2),
+	]
+
+	var chooser = preload("res://addons/escoria-dialog-simple/chooser/simple.tscn").instantiate()
+	add_child(chooser)
+	chooser.set_dialog(dialog)
+	chooser.show_chooser()
+
+	assert_bool(chooser.get_node("Timer").is_stopped()).is_false()
+
+	chooser.queue_free()
 
 
 func test_dialog_start_invalid_avatar_type_returns_error() -> void:
@@ -1677,3 +1783,11 @@ func _compile_fixture_script(name: String) -> ESCScript:
 
 func _fixture_path(name: String) -> String:
 	return "res://addons/escoria-core/testing/ashes/interpreter/fixtures/%s" % name
+
+
+func _make_dialog_option(text: String, source_option_index: int) -> ESCDialogOption:
+	var option := ESCDialogOption.new()
+	option.option = text
+	option.source_option_index = source_option_index
+	option.set_is_valid(true)
+	return option

--- a/addons/escoria-core/testing/ashes/interpreter/fixtures/dialog_timeout_hidden_authored_default_after_filtering.esc
+++ b/addons/escoria-core/testing/ashes/interpreter/fixtures/dialog_timeout_hidden_authored_default_after_filtering.esc
@@ -1,0 +1,10 @@
+:talk
+	global show_first = false
+
+	?! "-" 5 1
+		- "First option" [show_first]
+			break
+		- "Second option"
+			break
+		- "Third option"
+			break

--- a/addons/escoria-core/testing/ashes/interpreter/fixtures/dialog_timeout_visible_authored_default_after_filtering.esc
+++ b/addons/escoria-core/testing/ashes/interpreter/fixtures/dialog_timeout_visible_authored_default_after_filtering.esc
@@ -1,0 +1,10 @@
+:talk
+	global show_first = false
+
+	?! "-" 5 3
+		- "First option" [show_first]
+			break
+		- "Second option"
+			break
+		- "Third option"
+			break

--- a/addons/escoria-dialog-simple/chooser/simple.gd
+++ b/addons/escoria-dialog-simple/chooser/simple.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 
 
 # Process the timeout display
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if $MarginContainer.visible and self.dialog and self.dialog.timeout > 0:
 		$TimerProgress.value = (
 			self.dialog.timeout - $Timer.time_left
@@ -26,28 +26,28 @@ func _process(delta: float) -> void:
 
 # Show the chooser
 func show_chooser():
-	var _vbox = $MarginContainer/ScrollContainer/VBoxContainer
-	for option_node in _vbox.get_children():
-		_vbox.remove_child(option_node)
+	var vbox = $MarginContainer/ScrollContainer/VBoxContainer
+	for option_node in vbox.get_children():
+		vbox.remove_child(option_node)
 
 	_remove_avatar()
 
 	for option in self.dialog.options:
 		if option.is_valid():
-			var _option_node = Button.new()
-			_option_node.text = (option as ESCDialogOption).option
-			_option_node.flat = true
-			_option_node.add_theme_color_override("font_color", color_normal)
-			_option_node.add_theme_color_override("font_color_hover", color_hover)
-			_vbox.add_child(_option_node)
+			var option_node = Button.new()
+			option_node.text = (option as ESCDialogOption).option
+			option_node.flat = true
+			option_node.add_theme_color_override("font_color", color_normal)
+			option_node.add_theme_color_override("font_color_hover", color_hover)
+			vbox.add_child(option_node)
 
-			_option_node.pressed.connect(_on_answer_selected.bind(option))
+			option_node.pressed.connect(_on_answer_selected.bind(option))
 
 	# If we've no options left, signify as much and start the timer with a
 	# very short interval so the appropriate signal can be fired. Note that
 	# we have to fire the signal AFTER this method returns as the caller
 	# is almost certainly yielding after this method returns.
-	if _vbox.get_child_count() == 0:
+	if vbox.get_child_count() == 0:
 		_no_more_options = true
 		$Timer.start(0.05)
 		return

--- a/addons/escoria-dialog-simple/chooser/simple.gd
+++ b/addons/escoria-dialog-simple/chooser/simple.gd
@@ -59,8 +59,10 @@ func show_chooser():
 
 	$MarginContainer.show()
 
-	if self.dialog.timeout > 0:
+	if self.dialog.timeout > 0 and self.dialog.get_timeout_option():
 		$Timer.start(self.dialog.timeout)
+	else:
+		$TimerProgress.value = 0
 
 
 # Hide the chooser
@@ -88,7 +90,7 @@ func _on_answer_selected(option: ESCDialogOption):
 
 # The timeout came and a option was selected
 func _on_Timer_timeout() -> void:
-	var option_chosen = null if _no_more_options else self.dialog.options[self.dialog.timeout_option - 1]
+	var option_chosen = null if _no_more_options else self.dialog.get_timeout_option()
 	_no_more_options = false
 	_option_chosen(option_chosen)
 

--- a/game/dialog_avatars/player_dialog_options_avatar.tscn
+++ b/game/dialog_avatars/player_dialog_options_avatar.tscn
@@ -1,0 +1,10 @@
+[gd_scene format=3 uid="uid://c1l1ws72tw5dp"]
+
+[ext_resource type="Texture2D" uid="uid://biv4ritcbiojc" path="res://game/dialog_avatars/player.tres" id="1_6q4k4"]
+
+[node name="PlayerDialogOptionsAvatar" type="Node2D" unique_id=1986428703]
+
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=1637938423]
+position = Vector2(418, 35.999992)
+scale = Vector2(4.5434785, 3.7962964)
+texture = ExtResource("1_6q4k4")

--- a/game/rooms/room06/esc/worker.esc
+++ b/game/rooms/room06/esc/worker.esc
@@ -12,6 +12,7 @@
 		turn_to("worker", "player")
 		say("worker", "If you talk to me again")
 		say("worker", "I will not say this opening sentence.")
+		say("worker", "Also, if you take too long, the game will decide which question to ask me!")
 		talked_once = true
 
 	# Reset flag so the Loom conversation will be available every time 
@@ -23,7 +24,7 @@
 
 	loom_conversation_done = false
 	turn_to("worker", "player")
-	?!
+	?! "res://game/dialog_avatars/player_dialog_options_avatar.tscn" 5 1
 		- "What is your name?"
 			say("current_player", "Who are you?")
 
@@ -42,7 +43,7 @@
 		- "Can I ask you about Loom?" [!loom_conversation_done]
 			say("current_player", "What do you know about Loom?")
 			say("worker", "What do you want to know about Loom?")
-			?!
+			?! "res://game/dialog_avatars/player_dialog_options_avatar.tscn"
 				- "Could it be created in Escoria?" #[!loom_conversation_done]
 					say("player",	"Could Loom be created in Escoria?")
 					say("worker",	"Yes!")


### PR DESCRIPTION
Includes demo of these features in room 6, along w/ new unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dialog timeout handling now respects authored option ordering so timeouts target the intended visible choice.
  * Added a player avatar asset for dialog choice UI.

* **Bug Fixes**
  * Timeout selection and chooser timer now behave correctly when dialog choices are dynamically filtered; timer won't start if the timeout default is hidden.

* **Tests**
  * Added tests covering timeout mapping and chooser timer behavior in filtered dialog scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->