### PR TITLE
fix: pass telekinetic flag check if no event

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -685,6 +685,8 @@ func perform_inputevent_on_object(
 
 
 func _telekinetic_applies_to(event: ESCGrammarStmts.Event) -> bool:
+	if event == null:
+		return false
 	if event.get_flags_with_conditions().has("TK"):
 		var tk_flag_condition = event.get_flags_with_conditions().get("TK")
 

--- a/addons/escoria-core/testing/issue_946_room_transition_test.gd.uid
+++ b/addons/escoria-core/testing/issue_946_room_transition_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dd4msfbyuho46

--- a/addons/escoria-ui-keyboard-9verbs/game.gd
+++ b/addons/escoria-ui-keyboard-9verbs/game.gd
@@ -166,14 +166,14 @@ func element_focused(element_id: String) -> void:
 		# (ie verb+item(+target)) because the action is now being executed
 		# and the tooltip is already set because the item was focused
 		# (see element_focused() and inventory_item_focused())
-		ESCActionManager.ACTION_INPUT_STATE.COMPLETED:
+		ESCActionManager.ActionInputState.COMPLETED:
 			return
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM, \
+		ESCActionManager.ActionInputState.AWAITING_ITEM:
 			tooltip.set_target(target_obj.tooltip_name)
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_TARGET_ITEM:
 			tooltip.set_target2(target_obj.tooltip_name)
 
 
@@ -183,15 +183,15 @@ func element_unfocused() -> void:
 		# (ie verb+item(+target)) because the action is now being executed
 		# and the tooltip is already set because the item was focused
 		# (see element_focused() and inventory_item_focused())
-		ESCActionManager.ACTION_INPUT_STATE.COMPLETED:
+		ESCActionManager.ActionInputState.COMPLETED:
 			return
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM, \
+		ESCActionManager.ActionInputState.AWAITING_ITEM:
 			tooltip.set_target("")
 			verbs_menu.unselect_actions()
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_TARGET_ITEM:
 			tooltip.set_target2("")
 
 
@@ -213,17 +213,17 @@ func left_click_on_item(item_global_id: String, event: InputEvent) -> void:
 		# (ie verb+item(+target)) because the action is now being executed
 		# and the tooltip is already set because the item was focused
 		# (see element_focused() and inventory_item_focused())
-		ESCActionManager.ACTION_INPUT_STATE.COMPLETED:
+		ESCActionManager.ActionInputState.COMPLETED:
 			return
 
 		# Just clicked on the item
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM, \
+		ESCActionManager.ActionInputState.AWAITING_ITEM:
 			tooltip.set_target(target_obj.tooltip_name)
 
 		# Clicked on item and now we're awaiting a target item
 		# This means we clicked the tool and we now need a target
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_TARGET_ITEM:
 			tooltip.set_target(target_obj.tooltip_name, true)
 
 
@@ -261,17 +261,17 @@ func left_click_on_inventory_item(inventory_item_global_id: String, event: Input
 		# (ie verb+item(+target)) because the action is now being executed
 		# and the tooltip is already set because the item was focused
 		# (see element_focused() and inventory_item_focused())
-		ESCActionManager.ACTION_INPUT_STATE.COMPLETED:
+		ESCActionManager.ActionInputState.COMPLETED:
 			return
 
 		# Just clicked on the inventory item: do nothing special
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM, \
+		ESCActionManager.ActionInputState.AWAITING_ITEM:
 			return
 
 		# Clicked on inventory item and now we're awaiting a target item
 		# This means we clicked the tool and we now need a target
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_TARGET_ITEM:
 			tooltip.set_target(target_obj.tooltip_name, true)
 
 
@@ -297,35 +297,35 @@ func inventory_item_focused(inventory_item_global_id: String) -> void:
 		# (ie verb+item(+target)) because the action is now being executed
 		# and the tooltip is already set because the item was focused
 		# (see element_focused() and inventory_item_focused())
-		ESCActionManager.ACTION_INPUT_STATE.COMPLETED:
+		ESCActionManager.ActionInputState.COMPLETED:
 			return
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM, \
+		ESCActionManager.ActionInputState.AWAITING_ITEM:
 			tooltip.set_target(target_obj.tooltip_name)
 
 			# Hovering an ESCItem highlights its default action
 			if escoria.action_manager.current_action != VERB_USE and target_obj is ESCItem:
 				verbs_menu.set_by_name(target_obj.default_action)
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_TARGET_ITEM:
 			tooltip.set_target2(target_obj.tooltip_name)
 
 
 func inventory_item_unfocused() -> void:
 
 	match escoria.action_manager.action_state:
-		ESCActionManager.ACTION_INPUT_STATE.COMPLETED:
+		ESCActionManager.ActionInputState.COMPLETED:
 			# Don't change the tooltip if an action input is completed
 			# (ie verb+item(+target)) because the action is now being executed
 			return
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM, \
+		ESCActionManager.ActionInputState.AWAITING_ITEM:
 			tooltip.set_target("")
 			verbs_menu.unselect_actions()
 
-		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
+		ESCActionManager.ActionInputState.AWAITING_TARGET_ITEM:
 			tooltip.set_target2("")
 
 

--- a/addons/escoria-ui-keyboard-9verbs/game.gd
+++ b/addons/escoria-ui-keyboard-9verbs/game.gd
@@ -1,17 +1,6 @@
 extends ESCGame
 
 
-const VERB_CLOSE = "close"
-const VERB_GIVE = "give"
-const VERB_LOOK = "look"
-const VERB_OPEN = "open"
-const VERB_PICKUP = "pickup"
-const VERB_PULL = "pull"
-const VERB_PUSH = "push"
-const VERB_TALK = "talk"
-const VERB_USE = "use"
-
-
 """
 Implement methods to react to inputs.
 
@@ -49,6 +38,17 @@ Implement methods to react to inputs.
 - _on_event_done(event_name: String)
 """
 
+const VERB_CLOSE = "close"
+const VERB_GIVE = "give"
+const VERB_LOOK = "look"
+const VERB_OPEN = "open"
+const VERB_PICKUP = "pickup"
+const VERB_PULL = "pull"
+const VERB_PUSH = "push"
+const VERB_TALK = "talk"
+const VERB_USE = "use"
+
+const INPUT_MAP = preload("res://addons/escoria-ui-keyboard-9verbs/input_map.gd")
 
 @onready var verbs_menu = $ui/Control/panel_down/VBoxContainer/HBoxContainer\
 		/VerbsMargin/verbs_menu
@@ -58,7 +58,6 @@ Implement methods to react to inputs.
 		/MainMargin/VBoxContainer/room_select
 @onready var inventory_ui = $ui/Control/panel_down/VBoxContainer/HBoxContainer\
 		/InventoryMargin/inventory_ui
-const input_map = preload("res://addons/escoria-ui-keyboard-9verbs/input_map.gd")
 
 func _enter_tree():
 	var room_selector_parent = $ui/Control/panel_down/VBoxContainer\
@@ -75,46 +74,45 @@ func _enter_tree():
 
 	var input_handler = Callable(self, "_process_input")
 	escoria.inputs_manager.register_custom_input_handler(input_handler)
-	input_map.add_actions_to_input_map()
+	INPUT_MAP.add_actions_to_input_map()
 
 
 func _exit_tree():
 	escoria.inputs_manager.register_custom_input_handler(null)
-	input_map.erase_actions_from_input_map()
+	INPUT_MAP.erase_actions_from_input_map()
 
 
 func _process_input(event: InputEvent, is_default_state: bool) -> bool:
 	if not is_default_state:
 		return false
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_OPEN):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_OPEN):
 		verbs_menu.on_action_selected(VERB_OPEN)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_PICKUP):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_PICKUP):
 		verbs_menu.on_action_selected(VERB_PICKUP)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_PUSH):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_PUSH):
 		verbs_menu.on_action_selected(VERB_PUSH)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_CLOSE):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_CLOSE):
 		verbs_menu.on_action_selected(VERB_CLOSE)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_LOOK):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_LOOK):
 		verbs_menu.on_action_selected(VERB_LOOK)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_PULL):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_PULL):
 		verbs_menu.on_action_selected(VERB_PULL)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_GIVE):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_GIVE):
 		verbs_menu.on_action_selected(VERB_GIVE)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_USE):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_USE):
 		verbs_menu.on_action_selected(VERB_USE)
 		return true
-	elif event.is_action_pressed(input_map.ACTION_SET_VERB_TALK):
+	if event.is_action_pressed(INPUT_MAP.ACTION_SET_VERB_TALK):
 		verbs_menu.on_action_selected(VERB_TALK)
 		return true
-	else:
-		return false
+	return false
 
 
 ## BACKGROUND ##


### PR DESCRIPTION
+ apply forgotten renames in 9verbs plugin

This fixes an error when left clicking an item to simply walk towards it, with 9verbs enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash when action handling received null/empty input, improving interaction stability.

* **Refactor**
  * Streamlined keyboard input and verb/tooltip state handling for more predictable, maintainable behavior.

* **Tests**
  * Added a UID test resource to support a room-transition test scenario.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/godot-escoria/escoria-demo-game/pull/1234)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->