### PR TITLE
fix: crash on speedup immediate showing of dialog line (zero time per character)

### DIFF
--- a/addons/escoria-dialog-simple/types/floating.gd
+++ b/addons/escoria-dialog-simple/types/floating.gd
@@ -8,6 +8,7 @@ signal say_finished
 # Signal emitted when text has just become fully visible
 signal say_visible
 
+var dialog_location_node = null
 
 # The text speed per character for normal display
 var _text_time_per_character: float
@@ -30,8 +31,6 @@ var _is_speeding_up: bool = false
 
 # The current line of text being displayed.
 var _current_line: String
-
-var dialog_location_node = null
 
 
 # Tween node for text animation
@@ -179,7 +178,7 @@ func say(character: String, line: String) :
 	if time_show_full_text == 0.0:
 		# show the dialog line immediately and wait a little for player to have a chance to read
 		text_node.visible_ratio = 1.0
-		await get_tree().create_timer(0.05 * len(_current_line)).timeout
+		#await get_tree().create_timer(_calculate_time_to_disappear()).timeout
 		_on_dialog_line_typed("","")
 	else:
 		tween.interpolate_property(text_node, "visible_ratio",
@@ -198,7 +197,7 @@ func speedup():
 		if time_show_full_text == 0.0:
 			# show the dialog line immediately and wait a little for player to have a chance to read
 			text_node.visible_ratio = 1.0
-			await get_tree().create_timer(0.05 * len(_current_line)).timeout
+			#await get_tree().create_timer(_calculate_time_to_disappear()).timeout
 			_on_dialog_line_typed("","")
 		else:
 			tween.interpolate_property(text_node, "visible_ratio",
@@ -235,7 +234,7 @@ func _on_dialog_line_typed(_object, _key):
 
 
 func _calculate_time_to_disappear() -> float:
-	return (_get_number_of_words() / _reading_speed_in_wpm as float) * 60.0
+	return (_get_number_of_words() / float(_reading_speed_in_wpm)) * 60.0
 
 
 func _get_number_of_words() -> int:

--- a/addons/escoria-dialog-simple/types/floating.gd
+++ b/addons/escoria-dialog-simple/types/floating.gd
@@ -175,12 +175,16 @@ func say(character: String, line: String) :
 	text_node.visible_ratio = 0.0
 	var time_show_full_text = _text_time_per_character / 1000 * len(_current_line)
 
-	tween.reset()
-
-	tween.interpolate_property(text_node, "visible_ratio",
-		0.0, 1.0, time_show_full_text,
-		Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
-	tween.play()
+	if time_show_full_text == 0.0:
+		text_node.visible_ratio = 1.0
+		await get_tree().create_timer(0.08 * len(_current_line)).timeout
+		_on_dialog_line_typed("","")
+	else:
+		tween.reset()
+		tween.interpolate_property(text_node, "visible_ratio",
+			0.0, 1.0, time_show_full_text,
+			Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+		tween.play()
 	set_process(true)
 
 
@@ -190,12 +194,16 @@ func speedup():
 		_is_speeding_up = true
 		var time_show_full_text = _fast_text_time_per_character / 1000 * len(_current_line)
 
-		tween.reset()
-
-		tween.interpolate_property(text_node, "visible_ratio",
-			text_node.visible_ratio, 1.0, time_show_full_text,
-			Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
-		tween.play()
+		if time_show_full_text == 0.0:
+			text_node.visible_ratio = 1.0
+			await get_tree().create_timer(0.08 * len(_current_line)).timeout
+			_on_dialog_line_typed("","")
+		else:
+			tween.reset()
+			tween.interpolate_property(text_node, "visible_ratio",
+				text_node.visible_ratio, 1.0, time_show_full_text,
+				Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+			tween.play()
 
 
 # Called by the dialog player when user wants to finish dialogue immediately.
@@ -209,7 +217,7 @@ func finish():
 
 # To be called if voice audio has finished.
 func voice_audio_finished():
-		_stop_character_talking()
+	_stop_character_talking()
 
 
 # The dialog line was printed, start the waiting time and then finish
@@ -226,7 +234,7 @@ func _on_dialog_line_typed(object, key):
 
 
 func _calculate_time_to_disappear() -> float:
-	return (_get_number_of_words() / _reading_speed_in_wpm as float) * 60
+	return (_get_number_of_words() / _reading_speed_in_wpm as float) * 60.0
 
 
 func _get_number_of_words() -> int:

--- a/addons/escoria-dialog-simple/types/floating.gd
+++ b/addons/escoria-dialog-simple/types/floating.gd
@@ -22,7 +22,6 @@ var _reading_speed_in_wpm: int
 # Used to extract words from lines of text.
 var _word_regex: RegEx = RegEx.new()
 
-
 # Current character speaking, to keep track of reference for animation purposes
 var _current_character
 
@@ -31,6 +30,8 @@ var _is_speeding_up: bool = false
 
 # The current line of text being displayed.
 var _current_line: String
+
+var dialog_location_node = null
 
 
 # Tween node for text animation
@@ -42,7 +43,6 @@ var _current_line: String
 # Whether the dialog manager is paused
 @onready var is_paused: bool = true
 
-var dialog_location_node = null
 
 # Enable bbcode and catch the signal when a tween completed
 func _ready():
@@ -108,7 +108,7 @@ func _ready():
 	_current_line = ""
 
 
-func _process(delta):
+func _process(_delta: float):
 	if _current_character.is_inside_tree() and \
 			is_instance_valid(dialog_location_node):
 		# Position the RichTextLabel on the character's dialog position, if any.
@@ -175,12 +175,13 @@ func say(character: String, line: String) :
 	text_node.visible_ratio = 0.0
 	var time_show_full_text = _text_time_per_character / 1000 * len(_current_line)
 
+	tween.reset()
 	if time_show_full_text == 0.0:
+		# show the dialog line immediately and wait a little for player to have a chance to read
 		text_node.visible_ratio = 1.0
-		await get_tree().create_timer(0.08 * len(_current_line)).timeout
+		await get_tree().create_timer(0.05 * len(_current_line)).timeout
 		_on_dialog_line_typed("","")
 	else:
-		tween.reset()
 		tween.interpolate_property(text_node, "visible_ratio",
 			0.0, 1.0, time_show_full_text,
 			Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
@@ -195,11 +196,11 @@ func speedup():
 		var time_show_full_text = _fast_text_time_per_character / 1000 * len(_current_line)
 
 		if time_show_full_text == 0.0:
+			# show the dialog line immediately and wait a little for player to have a chance to read
 			text_node.visible_ratio = 1.0
-			await get_tree().create_timer(0.08 * len(_current_line)).timeout
+			await get_tree().create_timer(0.05 * len(_current_line)).timeout
 			_on_dialog_line_typed("","")
 		else:
-			tween.reset()
 			tween.interpolate_property(text_node, "visible_ratio",
 				text_node.visible_ratio, 1.0, time_show_full_text,
 				Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
@@ -222,7 +223,7 @@ func voice_audio_finished():
 
 # The dialog line was printed, start the waiting time and then finish
 # the dialog
-func _on_dialog_line_typed(object, key):
+func _on_dialog_line_typed(_object, _key):
 	_stop_character_talking()
 	text_node.visible_characters = -1
 

--- a/addons/escoria-dialog-simple/types/floating.gd
+++ b/addons/escoria-dialog-simple/types/floating.gd
@@ -175,16 +175,10 @@ func say(character: String, line: String) :
 	var time_show_full_text = _text_time_per_character / 1000 * len(_current_line)
 
 	tween.reset()
-	if time_show_full_text == 0.0:
-		# show the dialog line immediately and wait a little for player to have a chance to read
-		text_node.visible_ratio = 1.0
-		#await get_tree().create_timer(_calculate_time_to_disappear()).timeout
-		_on_dialog_line_typed("","")
-	else:
-		tween.interpolate_property(text_node, "visible_ratio",
+	tween.interpolate_property(text_node, "visible_ratio",
 			0.0, 1.0, time_show_full_text,
 			Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
-		tween.play()
+	tween.play()
 	set_process(true)
 
 
@@ -194,16 +188,10 @@ func speedup():
 		_is_speeding_up = true
 		var time_show_full_text = _fast_text_time_per_character / 1000 * len(_current_line)
 
-		if time_show_full_text == 0.0:
-			# show the dialog line immediately and wait a little for player to have a chance to read
-			text_node.visible_ratio = 1.0
-			#await get_tree().create_timer(_calculate_time_to_disappear()).timeout
-			_on_dialog_line_typed("","")
-		else:
-			tween.interpolate_property(text_node, "visible_ratio",
-				text_node.visible_ratio, 1.0, time_show_full_text,
-				Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
-			tween.play()
+		tween.interpolate_property(text_node, "visible_ratio",
+			text_node.visible_ratio, 1.0, time_show_full_text,
+			Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
+		tween.play()
 
 
 # Called by the dialog player when user wants to finish dialogue immediately.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog text now appears instantly when reveal timing is zero and end-of-line completion triggers reliably.
  * Faster, more consistent fast-finish behavior when speeding up text reveal.

* **Maintenance**
  * Timing calculations use explicit float math for consistent disappear durations.
  * Minor internal signature and parameter cleanups to improve processing stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/godot-escoria/escoria-demo-game/pull/1236)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->