### PR TITLE
fix(new-game): reset runtime state on restart

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
@@ -1,7 +1,7 @@
 ## A manager for ESC objects.
 ## @MANAGER
-extends Resource
 class_name ESCObjectManager
+extends Resource
 
 
 ## Reserved camera object.
@@ -91,6 +91,23 @@ func _init() -> void:
 	reserved_objects_container.objects = {}
 	room_objects.push_back(reserved_objects_container)
 
+	current_room_key = ESCRoomObjectsKey.new()
+
+
+## Clears all room-specific object and terrain state while preserving reserved
+## objects managed by Escoria itself.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func reset_game_state() -> void:
+	room_objects.clear()
+	room_objects.push_back(reserved_objects_container)
+	room_terrains.clear()
 	current_room_key = ESCRoomObjectsKey.new()
 
 
@@ -193,7 +210,7 @@ func register_object(object: ESCObject, room: ESCRoom = null, force: bool = fals
 		return
 	# Object exists in room, set it to is last state (if different from
 	# "default")
-	elif object.node is ESCItem and _object_exists_in_room(object, room_key):
+	if object.node is ESCItem and _object_exists_in_room(object, room_key):
 		# Object is already known, set its state to last known state
 		object.set_state(get_object(object.global_id).state)
 
@@ -352,13 +369,13 @@ func get_object(global_id: String, room: ESCRoom = null) -> ESCObject:
 	if global_id in RESERVED_OBJECTS:
 		if reserved_objects_container.objects.has(global_id):
 			return reserved_objects_container.objects[global_id]
-		else:
-			escoria.logger.warn(
-				self,
-				"Reserved object with global id %s not found in object manager!"
-					% global_id
-			)
-			return null
+
+		escoria.logger.warn(
+			self,
+			"Reserved object with global id %s not found in object manager!"
+				% global_id
+		)
+		return null
 
 	var room_key: ESCRoomObjectsKey
 
@@ -382,24 +399,24 @@ func get_object(global_id: String, room: ESCRoom = null) -> ESCObject:
 
 	if objects.has(global_id):
 		return objects[global_id]
-	else:
-		escoria.logger.warn(
-			self,
-			"Object with global id %s in room instance (%s, %s) not found. This can be safely ignored if a room was being searched for."
-			% [global_id, room_key.room_global_id, room_key.room_instance_id]
-		)
-		if escoria.inventory_manager.inventory_has(global_id):
-			# item is in the inventory and may be registered to a different room
-			for single_room in room_objects:
-				# these are arrays of the objects still registered for each room
-				if single_room.objects.has(global_id):
-					escoria.logger.info(
-						self,
-						"Object with global id %s found in room instance (%s, %s) through the inventory."
-						% [global_id, room_key.room_global_id, room_key.room_instance_id]
-					)
-					return single_room.objects[global_id]
-		return null
+
+	escoria.logger.warn(
+		self,
+		"Object with global id %s in room instance (%s, %s) not found. This can be safely ignored if a room was being searched for."
+		% [global_id, room_key.room_global_id, room_key.room_instance_id]
+	)
+	if escoria.inventory_manager.inventory_has(global_id):
+		# item is in the inventory and may be registered to a different room
+		for single_room in room_objects:
+			# these are arrays of the objects still registered for each room
+			if single_room.objects.has(global_id):
+				escoria.logger.info(
+					self,
+					"Object with global id %s found in room instance (%s, %s) through the inventory."
+					% [global_id, room_key.room_global_id, room_key.room_instance_id]
+				)
+				return single_room.objects[global_id]
+	return null
 
 
 ## Removes an object from the registry.[br]

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -267,7 +267,9 @@ func _event_exists_in_script(script: ESCScript, event_name: String) -> bool:
 func new_game():
 	escoria.event_manager.interrupt() # interrupt first because we're going to reset the interpreter
 	escoria.game_scene.escoria_show_ui()
+	_reset_new_game_runtime_state()
 	escoria.globals_manager.clear()
+	escoria.object_manager.reset_game_state()
 	escoria.interpreter_factory.reset_interpreter()
 	escoria.main.clear_previous_scene()
 	escoria.creating_new_game = true
@@ -277,6 +279,20 @@ func new_game():
 			true
 		)
 	run_event_from_script(escoria.start_script, escoria.event_manager.EVENT_NEW_GAME)
+
+
+func _reset_new_game_runtime_state() -> void:
+	escoria.action_manager.clear_current_action()
+	escoria.action_manager.clear_current_tool()
+	escoria.inputs_manager.hover_stack.clear()
+	escoria.inputs_manager.hotspot_focused = ""
+	escoria.inputs_manager.input_mode = escoria.inputs_manager.INPUT_ALL
+
+	if escoria.game_scene and escoria.game_scene.is_inside_tree():
+		escoria.game_scene.clear_tooltip()
+		escoria.game_scene.close_inventory()
+		escoria.game_scene.hide_main_menu()
+		escoria.game_scene.unpause_game()
 
 
 ## Function called to quit the game.[br]

--- a/addons/escoria-core/testing/esc_new_game_state_test.gd
+++ b/addons/escoria-core/testing/esc_new_game_state_test.gd
@@ -1,0 +1,38 @@
+# GdUnit generated TestSuite
+class_name ESCNewGameStateTest
+extends GdUnitTestSuite
+
+
+func test_new_game_runtime_reset_clears_transient_input_state() -> void:
+	var escoria_node = escoria.get_escoria()
+	var tool_node := ESCItem.new()
+	tool_node.global_id = "test_tool"
+	var tool_object := ESCObject.new(tool_node.global_id, tool_node)
+	var hovered_item := ESCItem.new()
+	hovered_item.global_id = "test_hovered_item"
+	hovered_item.z_index = 1
+
+	escoria.action_manager.set_current_action("use")
+	escoria.action_manager.current_tool = tool_object
+	escoria.action_manager.current_target = tool_object
+	escoria.action_manager.set_action_input_state(
+		ESCActionManager.ActionInputState.AWAITING_TARGET_ITEM
+	)
+	escoria.inputs_manager.hover_stack.hover_stack.append(hovered_item)
+	escoria.inputs_manager.hotspot_focused = "test_hotspot"
+	escoria.inputs_manager.input_mode = escoria.inputs_manager.INPUT_NONE
+
+	escoria_node._reset_new_game_runtime_state()
+
+	assert_str(escoria.action_manager.current_action).is_equal("")
+	assert_object(escoria.action_manager.current_tool).is_null()
+	assert_object(escoria.action_manager.current_target).is_null()
+	assert_int(escoria.action_manager.action_state).is_equal(
+		ESCActionManager.ActionInputState.AWAITING_VERB_OR_ITEM
+	)
+	assert_bool(escoria.inputs_manager.hover_stack.is_empty()).is_true()
+	assert_str(escoria.inputs_manager.hotspot_focused).is_equal("")
+	assert_int(escoria.inputs_manager.input_mode).is_equal(escoria.inputs_manager.INPUT_ALL)
+
+	tool_node.free()
+	hovered_item.free()

--- a/addons/escoria-core/testing/esc_new_game_state_test.gd.uid
+++ b/addons/escoria-core/testing/esc_new_game_state_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dce1ff86rtpla

--- a/addons/escoria-core/testing/esc_object_manager_test.gd
+++ b/addons/escoria-core/testing/esc_object_manager_test.gd
@@ -1,0 +1,79 @@
+# GdUnit generated TestSuite
+class_name ESCObjectManagerTest
+extends GdUnitTestSuite
+
+
+func test_reset_game_state_clears_persisted_room_object_state() -> void:
+	var object_manager := ESCObjectManager.new()
+	var room := ESCRoom.new()
+	room.global_id = "test_room"
+	object_manager.set_current_room(room)
+
+	var first_item := ESCItem.new()
+	first_item.global_id = "test_item"
+	var first_object := ESCObject.new(first_item.global_id, first_item)
+	object_manager.register_object(first_object, room, false, false)
+	first_object.set_state("opened")
+
+	var room_key := ESCRoomObjectsKey.new()
+	room_key.room_global_id = room.global_id
+	room_key.room_instance_id = room.get_instance_id()
+	object_manager.unregister_object(first_object, room_key)
+	assert_bool(object_manager.has(first_item.global_id, room)).is_true()
+
+	object_manager.reset_game_state()
+	assert_bool(object_manager.has(first_item.global_id, room)).is_false()
+
+	var second_item := ESCItem.new()
+	second_item.global_id = "test_item"
+	var second_object := ESCObject.new(second_item.global_id, second_item)
+	object_manager.set_current_room(room)
+	object_manager.register_object(second_object, room, false, false)
+
+	assert_str(object_manager.get_object(second_item.global_id, room).state).is_equal(
+		ESCObject.STATE_DEFAULT
+	)
+
+	first_item.free()
+	second_item.free()
+	room.free()
+
+
+func test_reset_game_state_preserves_reserved_objects() -> void:
+	var object_manager := ESCObjectManager.new()
+	var music_node := Node.new()
+
+	object_manager.register_object(
+		ESCObject.new(ESCObjectManager.MUSIC, music_node),
+		null,
+		true,
+		false
+	)
+
+	object_manager.reset_game_state()
+
+	assert_bool(object_manager.has(ESCObjectManager.MUSIC)).is_true()
+	assert_object(object_manager.get_object(ESCObjectManager.MUSIC).node).is_same(music_node)
+
+	music_node.free()
+
+
+func test_reset_game_state_clears_saved_terrain_state() -> void:
+	var object_manager := ESCObjectManager.new()
+	var room := ESCRoom.new()
+	room.global_id = "test_room"
+	var navigation_region := NavigationRegion2D.new()
+
+	object_manager.set_current_room(room)
+	object_manager.register_terrain(
+		ESCObject.new("test_terrain", navigation_region),
+		room
+	)
+	assert_int(object_manager.room_terrains.size()).is_equal(1)
+
+	object_manager.reset_game_state()
+
+	assert_int(object_manager.room_terrains.size()).is_equal(0)
+
+	navigation_region.free()
+	room.free()

--- a/addons/escoria-core/testing/esc_object_manager_test.gd.uid
+++ b/addons/escoria-core/testing/esc_object_manager_test.gd.uid
@@ -1,0 +1,1 @@
+uid://b5f3fwnatn16n


### PR DESCRIPTION
Fixes #983 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed new-game initialization to properly reset runtime state, including action manager, input state, and UI elements.

* **Tests**
  * Added comprehensive test suites to validate new-game state reset behavior and object manager state management across room transitions.

* **Refactor**
  * Enhanced object manager state handling for cleaner game state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/godot-escoria/escoria-demo-game/pull/1239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->