### PR TITLE
feat(signal): add new game started signal.

### DIFF
--- a/addons/escoria-core/game/esc_autoload.gd
+++ b/addons/escoria-core/game/esc_autoload.gd
@@ -240,7 +240,6 @@ func set_game_paused(p_paused: bool):
 ## Returns nothing.
 func new_game():
 	get_escoria().new_game()
-	new_game_started.emit()
 
 ## Called from main menu's "quit" button.[br]
 ## [br]

--- a/addons/escoria-core/game/esc_autoload.gd
+++ b/addons/escoria-core/game/esc_autoload.gd
@@ -2,6 +2,14 @@ extends Node
 ## This is Escoria's singleton script.
 ## It holds accessors to some utils, such as Escoria's logger.
 
+## Signal sent when Escoria starts a new game[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+signal new_game_started
+
 ## Signal sent when Escoria is paused[br]
 ## [br]
 ## #### Parameters[br]
@@ -232,6 +240,7 @@ func set_game_paused(p_paused: bool):
 ## Returns nothing.
 func new_game():
 	get_escoria().new_game()
+	new_game_started.emit()
 
 ## Called from main menu's "quit" button.[br]
 ## [br]

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -195,7 +195,7 @@ func run_event_from_script(script: ESCScript, event_name: String, _from_statemen
 			"Requested event %s on unloaded script %s." % [event_name, script] +
 			"Please load the ESC script using esc_compiler.load_esc_file()."
 		)
-		return ESCExecution.RC_WONT_QUEUE		
+		return ESCExecution.RC_WONT_QUEUE
 
 	if not _event_exists_in_script(script, event_name):
 		return ESCExecution.RC_WONT_QUEUE
@@ -210,7 +210,7 @@ func run_event_from_script(script: ESCScript, event_name: String, _from_statemen
 			self,
 			"Start event of the start script returned unsuccessful: %d." % rc[0]
 		)
-		
+
 	return rc[0]
 
 
@@ -280,7 +280,7 @@ func new_game():
 			true,
 			true
 		)
-	
+
 	var rc = await run_event_from_script(escoria.start_script, escoria.event_manager.EVENT_NEW_GAME)
 	if rc == ESCExecution.RC_OK:
 		escoria.new_game_started.emit()

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -195,6 +195,7 @@ func run_event_from_script(script: ESCScript, event_name: String, _from_statemen
 			"Requested event %s on unloaded script %s." % [event_name, script] +
 			"Please load the ESC script using esc_compiler.load_esc_file()."
 		)
+		return ESCExecution.RC_WONT_QUEUE		
 
 	if not _event_exists_in_script(script, event_name):
 		return ESCExecution.RC_WONT_QUEUE

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -187,7 +187,7 @@ func _input(event: InputEvent):
 ## [br]
 ## #### Returns[br]
 ## [br]
-## Returns Nothing. Waits for the event to finish before returning. (`Variant`)
+## Returns ESCExecution. Waits for the event to finish before returning. (`Variant`)
 func run_event_from_script(script: ESCScript, event_name: String, _from_statement_id: int = 0):
 	if script == null:
 		escoria.logger.error(
@@ -197,7 +197,7 @@ func run_event_from_script(script: ESCScript, event_name: String, _from_statemen
 		)
 
 	if not _event_exists_in_script(script, event_name):
-		return
+		return ESCExecution.RC_WONT_QUEUE
 
 	escoria.event_manager.queue_event(script.get_event_with_target(event_name))
 	var rc = await escoria.event_manager.event_finished
@@ -209,7 +209,8 @@ func run_event_from_script(script: ESCScript, event_name: String, _from_statemen
 			self,
 			"Start event of the start script returned unsuccessful: %d." % rc[0]
 		)
-		return
+		
+	return rc[0]
 
 
 ## Checks for the existence of both mandatory and optional events within a specified script.[br]
@@ -278,7 +279,10 @@ func new_game():
 			true,
 			true
 		)
-	run_event_from_script(escoria.start_script, escoria.event_manager.EVENT_NEW_GAME)
+	
+	var rc = await run_event_from_script(escoria.start_script, escoria.event_manager.EVENT_NEW_GAME)
+	if rc == ESCExecution.RC_OK:
+		escoria.new_game_started.emit()
 
 
 func _reset_new_game_runtime_state() -> void:


### PR DESCRIPTION
Adds new game started signal.

Allows addons to add functionalities and/or features when game starts.

Example use case:
- Game time handling & game achievements: https://git.fosil.eu/gymkhana/gymkhana/src/commit/c6a7ab376e524b54347fe3bcbe81523db8b04d19/addons/escoria-ui-return-monkey-island/achievements/rtmi_achievement_manager.gd#L28

Godot Timer must be added to the game tree to work. We use the signal to know when is possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "new game started" notification so integrations and UI can react when a new game begins.

* **Bug Fixes / Behavior Changes**
  * Game startup now awaits and checks the startup event result before emitting the "new game started" notification, preventing premature announcements and improving startup reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/godot-escoria/escoria-demo-game/pull/1240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->