### PR TITLE
feat(settings): add unified way to access custom settings

### DIFF
--- a/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
@@ -297,7 +297,4 @@ func save_settings():
 
 ## Returns a custom setting by key or an optional default value. Returns null if not found and no default value is defined.
 func get_custom_setting(key: String, default_value = null):
-	if custom_settings.has(key):
-		return custom_settings.get(key)
-
-	return default_value
+	return custom_settings.get(key, default_value)

--- a/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
@@ -293,3 +293,11 @@ func save_settings():
 			self,
 			"There was an issue writing settings %s" % save_path
 		)
+
+
+## Returns a custom setting by key or an optional default value. Returns null if not found and no default value is defined.
+func get_custom_setting(key: String, default_value = null):
+	if custom_settings.has(key):
+		return custom_settings.get(key)
+
+	return default_value


### PR DESCRIPTION
Adds an unified way for addons to access custom settings.
It's an utility function for addons.

We use it for extended custom menu options associated with an addon:
https://git.fosil.eu/gymkhana/gymkhana/src/commit/c6a7ab376e524b54347fe3bcbe81523db8b04d19/addons/escoria-ui-return-monkey-island-dialog-simple/types/floating.gd#L74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can now return a configurable value for custom settings when a key is missing, using an optional default.
  * No changes to existing settings load/save behavior.
  * Safer handling of absent configuration values, reducing unexpected nulls for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->