### PR TITLE
fix: address multiple wizard - item creator issues

### DIFF
--- a/addons/escoria-wizard/ItemCreator.tscn
+++ b/addons/escoria-wizard/ItemCreator.tscn
@@ -1,10 +1,10 @@
-[gd_scene load_steps=4 format=3 uid="uid://beawklamapteq"]
+[gd_scene format=3 uid="uid://beawklamapteq"]
 
 [ext_resource type="Script" uid="uid://bxj8cgfbk5r8f" path="res://addons/escoria-wizard/item_creator.gd" id="1"]
-[ext_resource type="Texture2D" uid="uid://b7ax2phlsg1x6" path="res://addons/escoria-wizard/graphics/inventory_preview.png" id="2"]
-[ext_resource type="Texture2D" uid="uid://bf47xbq6w4hou" path="res://addons/escoria-wizard/graphics/object_preview.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://mxyijpemwkkg" path="res://addons/escoria-wizard/graphics/inventory_preview.png" id="2"]
+[ext_resource type="Texture2D" uid="uid://d2chqmjr3qq3m" path="res://addons/escoria-wizard/graphics/object_preview.png" id="3"]
 
-[node name="ItemCreator" type="MarginContainer"]
+[node name="ItemCreator" type="MarginContainer" unique_id=691174334]
 custom_minimum_size = Vector2(500, 500)
 offset_left = 395.0
 offset_top = 50.0
@@ -14,50 +14,50 @@ size_flags_horizontal = 4
 size_flags_vertical = 4
 script = ExtResource("1")
 
-[node name="window_background_colour" type="ColorRect" parent="."]
+[node name="window_background_colour" type="ColorRect" parent="." unique_id=1006540274]
 custom_minimum_size = Vector2(500, 800)
 layout_mode = 2
 color = Color(0.235294, 0.341176, 0.290196, 1)
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1556992828]
 layout_mode = 2
 
-[node name="Control" type="CenterContainer" parent="VBoxContainer"]
+[node name="Control" type="CenterContainer" parent="VBoxContainer" unique_id=272720985]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 
-[node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/Control"]
+[node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/Control" unique_id=1294587700]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Control/CenterContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Control/CenterContainer" unique_id=1459294672]
 layout_mode = 2
 
-[node name="BackgroundObjectCheckBox" type="CheckBox" parent="VBoxContainer/Control/CenterContainer/HBoxContainer"]
+[node name="BackgroundObjectCheckBox" type="CheckBox" parent="VBoxContainer/Control/CenterContainer/HBoxContainer" unique_id=1733794135]
 layout_mode = 2
 text = "Create background object"
 
-[node name="InventoryItemCheckBox" type="CheckBox" parent="VBoxContainer/Control/CenterContainer/HBoxContainer"]
+[node name="InventoryItemCheckBox" type="CheckBox" parent="VBoxContainer/Control/CenterContainer/HBoxContainer" unique_id=1237062721]
 layout_mode = 2
 text = "Create inventory item"
 
-[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer" unique_id=1468681635]
 layout_mode = 2
 
-[node name="HelperHeading" type="MarginContainer" parent="VBoxContainer"]
+[node name="HelperHeading" type="MarginContainer" parent="VBoxContainer" unique_id=1282537158]
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 
-[node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/HelperHeading"]
+[node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/HelperHeading" unique_id=407105498]
 layout_mode = 2
 
-[node name="ObjectHeading" type="Label" parent="VBoxContainer/HelperHeading/CenterContainer"]
+[node name="ObjectHeading" type="Label" parent="VBoxContainer/HelperHeading/CenterContainer" unique_id=1913640739]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.592157, 0.87451, 0.533333, 1)
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
 text = "Object Creator"
 uppercase = true
 
-[node name="InventoryHeading" type="Label" parent="VBoxContainer/HelperHeading/CenterContainer"]
+[node name="InventoryHeading" type="Label" parent="VBoxContainer/HelperHeading/CenterContainer" unique_id=1615178370]
 visible = false
 layout_mode = 2
 theme_override_colors/font_color = Color(0.592157, 0.87451, 0.533333, 1)
@@ -65,10 +65,10 @@ theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
 text = "Inventory Item Creator"
 uppercase = true
 
-[node name="Description" type="MarginContainer" parent="VBoxContainer"]
+[node name="Description" type="MarginContainer" parent="VBoxContainer" unique_id=348444932]
 layout_mode = 2
 
-[node name="ObjectDescription" type="Label" parent="VBoxContainer/Description"]
+[node name="ObjectDescription" type="Label" parent="VBoxContainer/Description" unique_id=1367984222]
 layout_mode = 2
 text = "The object creator is used to create background objects
 that the player can interact with, but that will not become
@@ -79,7 +79,7 @@ is currently selected in the scene tree.
 "
 horizontal_alignment = 1
 
-[node name="InventoryDescription" type="Label" parent="VBoxContainer/Description"]
+[node name="InventoryDescription" type="Label" parent="VBoxContainer/Description" unique_id=609879510]
 visible = false
 layout_mode = 2
 text = "The inventory item creator is used to create objects
@@ -92,88 +92,91 @@ game must live in the same folder.
 "
 horizontal_alignment = 1
 
-[node name="Content" type="MarginContainer" parent="VBoxContainer"]
+[node name="Content" type="MarginContainer" parent="VBoxContainer" unique_id=990904092]
 custom_minimum_size = Vector2(0, 500)
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 0
 theme_override_constants/margin_right = 20
 
-[node name="GridContainer" type="GridContainer" parent="VBoxContainer/Content"]
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/Content" unique_id=158727013]
 custom_minimum_size = Vector2(460, 500)
 layout_mode = 2
 columns = 3
 
-[node name="ItemNameLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="ItemNameLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=364727612]
 layout_mode = 2
 text = "Item name:"
 
-[node name="ItemName" type="LineEdit" parent="VBoxContainer/Content/GridContainer"]
+[node name="ItemName" type="LineEdit" parent="VBoxContainer/Content/GridContainer" unique_id=331794259]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 text = "replace_me"
 
-[node name="BlankItem" type="Control" parent="VBoxContainer/Content/GridContainer"]
+[node name="BlankItem" type="Control" parent="VBoxContainer/Content/GridContainer" unique_id=63798475]
 layout_mode = 2
 
-[node name="ItemGlobalIDLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="ItemGlobalIDLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=1865740109]
 layout_mode = 2
 text = "Global ID:"
 
-[node name="ItemGlobalID" type="LineEdit" parent="VBoxContainer/Content/GridContainer"]
+[node name="ItemGlobalID" type="LineEdit" parent="VBoxContainer/Content/GridContainer" unique_id=2143247033]
 layout_mode = 2
 
-[node name="BlankItem2" type="Control" parent="VBoxContainer/Content/GridContainer"]
+[node name="BlankItem2" type="Control" parent="VBoxContainer/Content/GridContainer" unique_id=264709736]
 layout_mode = 2
 
-[node name="StartsInteractiveLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="StartsInteractiveLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=479125211]
 custom_minimum_size = Vector2(110, 0)
 layout_mode = 2
 text = "Is 'Interactive':"
 
-[node name="StartsInteractiveCheckBox" type="CheckBox" parent="VBoxContainer/Content/GridContainer"]
+[node name="StartsInteractiveCheckBox" type="CheckBox" parent="VBoxContainer/Content/GridContainer" unique_id=247353906]
 layout_mode = 2
 tooltip_text = "When the room first loads, can the player interact with this?"
 button_pressed = true
 
-[node name="BlankItem3" type="Control" parent="VBoxContainer/Content/GridContainer"]
+[node name="BlankItem3" type="Control" parent="VBoxContainer/Content/GridContainer" unique_id=107820231]
 layout_mode = 2
 
-[node name="DefaultActionLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="DefaultActionLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=732630412]
 layout_mode = 2
 text = "Default action:
 "
 vertical_alignment = 1
 
-[node name="DefaultActionOption" type="OptionButton" parent="VBoxContainer/Content/GridContainer"]
+[node name="DefaultActionOption" type="OptionButton" parent="VBoxContainer/Content/GridContainer" unique_id=606279851]
 custom_minimum_size = Vector2(200, 31)
 layout_mode = 2
+selected = 0
+item_count = 1
+popup/item_0/id = 0
 
-[node name="BlankItem4" type="Control" parent="VBoxContainer/Content/GridContainer"]
+[node name="BlankItem4" type="Control" parent="VBoxContainer/Content/GridContainer" unique_id=433328003]
 layout_mode = 2
 
-[node name="ImagePathLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="ImagePathLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=398723320]
 layout_mode = 2
 text = "Item graphic:"
 
-[node name="ImagePath" type="LineEdit" parent="VBoxContainer/Content/GridContainer"]
+[node name="ImagePath" type="LineEdit" parent="VBoxContainer/Content/GridContainer" unique_id=938646351]
 layout_mode = 2
 editable = false
 
-[node name="ChangeImageButton" type="Button" parent="VBoxContainer/Content/GridContainer"]
+[node name="ChangeImageButton" type="Button" parent="VBoxContainer/Content/GridContainer" unique_id=1854196443]
 layout_mode = 2
 text = "Change Image"
 
-[node name="PreviewLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="PreviewLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=44519053]
 layout_mode = 2
 text = "Preview:"
 
-[node name="Preview" type="ColorRect" parent="VBoxContainer/Content/GridContainer"]
+[node name="Preview" type="ColorRect" parent="VBoxContainer/Content/GridContainer" unique_id=92417030]
 custom_minimum_size = Vector2(240, 240)
 layout_mode = 2
 color = Color(0.121569, 0.196078, 0.0823529, 1)
 
-[node name="BackgroundColour" type="ColorRect" parent="VBoxContainer/Content/GridContainer/Preview"]
+[node name="BackgroundColour" type="ColorRect" parent="VBoxContainer/Content/GridContainer/Preview" unique_id=1329101639]
 custom_minimum_size = Vector2(232, 232)
 layout_mode = 0
 offset_left = 4.0
@@ -182,7 +185,7 @@ offset_right = 236.0
 offset_bottom = 236.0
 color = Color(0.254902, 0.231373, 0.231373, 1)
 
-[node name="InventoryPreview" type="TextureRect" parent="VBoxContainer/Content/GridContainer/Preview"]
+[node name="InventoryPreview" type="TextureRect" parent="VBoxContainer/Content/GridContainer/Preview" unique_id=1373748569]
 visible = false
 layout_mode = 0
 offset_left = 4.0
@@ -191,7 +194,7 @@ offset_right = 236.0
 offset_bottom = 236.0
 texture = ExtResource("2")
 
-[node name="ObjectPreview" type="TextureRect" parent="VBoxContainer/Content/GridContainer/Preview"]
+[node name="ObjectPreview" type="TextureRect" parent="VBoxContainer/Content/GridContainer/Preview" unique_id=134323334]
 layout_mode = 0
 offset_left = 4.0
 offset_top = 4.0
@@ -199,7 +202,7 @@ offset_right = 236.0
 offset_bottom = 236.0
 texture = ExtResource("3")
 
-[node name="Preview" type="TextureRect" parent="VBoxContainer/Content/GridContainer/Preview"]
+[node name="Preview" type="TextureRect" parent="VBoxContainer/Content/GridContainer/Preview" unique_id=776503273]
 custom_minimum_size = Vector2(232, 232)
 layout_mode = 0
 offset_left = 4.0
@@ -207,92 +210,96 @@ offset_top = 4.0
 offset_right = 236.0
 offset_bottom = 236.0
 
-[node name="BlankItem5" type="Control" parent="VBoxContainer/Content/GridContainer"]
+[node name="BlankItem5" type="Control" parent="VBoxContainer/Content/GridContainer" unique_id=1394861351]
 layout_mode = 2
 
-[node name="ImageSizeLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="ImageSizeLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=212608889]
 layout_mode = 2
 text = "Image size:"
 
-[node name="ImageSize" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="ImageSize" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=1613836739]
 layout_mode = 2
 text = "(0, 0)"
 
-[node name="BlankItem6" type="Control" parent="VBoxContainer/Content/GridContainer"]
+[node name="BlankItem6" type="Control" parent="VBoxContainer/Content/GridContainer" unique_id=1884527510]
 layout_mode = 2
 
-[node name="InventoryPathLabel" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="InventoryPathLabel" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=1516523054]
 visible = false
 layout_mode = 2
 text = "Inventory path:"
 
-[node name="InventoryPath" type="Label" parent="VBoxContainer/Content/GridContainer"]
+[node name="InventoryPath" type="Label" parent="VBoxContainer/Content/GridContainer" unique_id=692354482]
 visible = false
 layout_mode = 2
 text = "res://"
 
-[node name="ChangePathButton" type="Button" parent="VBoxContainer/Content/GridContainer"]
+[node name="ChangePathButton" type="Button" parent="VBoxContainer/Content/GridContainer" unique_id=216018542]
 visible = false
 layout_mode = 2
-text = "Change Path3D"
+text = "Change Inventory Path"
 
-[node name="BlankItem7" type="Control" parent="VBoxContainer/Content/GridContainer"]
+[node name="BlankItem7" type="Control" parent="VBoxContainer/Content/GridContainer" unique_id=816977697]
 visible = false
 layout_mode = 2
 
-[node name="Buttons" type="MarginContainer" parent="VBoxContainer"]
+[node name="Buttons" type="MarginContainer" parent="VBoxContainer" unique_id=317694956]
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/margin_bottom = 10
 
-[node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/Buttons"]
+[node name="CenterContainer" type="CenterContainer" parent="VBoxContainer/Buttons" unique_id=832093664]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Buttons/CenterContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Buttons/CenterContainer" unique_id=308534454]
 layout_mode = 2
 
-[node name="CreateButton" type="Button" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer"]
+[node name="CreateButton" type="Button" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer" unique_id=103034756]
 layout_mode = 2
 text = "Create Object"
 
-[node name="Spacer" type="Control" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer"]
+[node name="Spacer" type="Control" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer" unique_id=635434229]
 custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
 
-[node name="ClearButton" type="Button" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer"]
+[node name="ClearButton" type="Button" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer" unique_id=1557616416]
 layout_mode = 2
 text = "Clear All"
 
-[node name="Spacer2" type="Control" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer"]
+[node name="Spacer2" type="Control" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer" unique_id=959146374]
 custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
 
-[node name="ExitButton" type="Button" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer"]
+[node name="ExitButton" type="Button" parent="VBoxContainer/Buttons/CenterContainer/HBoxContainer" unique_id=1012963769]
 layout_mode = 2
 text = "Main Menu"
 
-[node name="LoadObjectGraphic" type="CenterContainer" parent="."]
+[node name="LoadObjectGraphic" type="CenterContainer" parent="." unique_id=2039551690]
 visible = false
 layout_mode = 2
 mouse_filter = 2
 
-[node name="LoadObjectFileDialog" type="FileDialog" parent="LoadObjectGraphic"]
+[node name="LoadObjectFileDialog" type="FileDialog" parent="LoadObjectGraphic" unique_id=183617470]
+oversampling_override = 1.0
+title = "Open a File"
+position = Vector2i(0, 36)
+file_mode = 0
 filters = PackedStringArray("*.png", "*.bmp", "*.jpg", "*.jpeg", "*.webp", "*.tga")
 
-[node name="Windows" type="CenterContainer" parent="."]
+[node name="Windows" type="CenterContainer" parent="." unique_id=353631974]
 visible = false
 layout_mode = 2
 
-[node name="ConfirmationDialog" type="ConfirmationDialog" parent="Windows"]
+[node name="ConfirmationDialog" type="ConfirmationDialog" parent="Windows" unique_id=739679800]
 dialog_text = "WARNING!
 
 If you continue you will lose the current object."
 
-[node name="ErrorDialog" type="AcceptDialog" parent="Windows"]
+[node name="ErrorDialog" type="AcceptDialog" parent="Windows" unique_id=1922609345]
 
-[node name="CreateCompleteDialog" type="AcceptDialog" parent="Windows"]
+[node name="CreateCompleteDialog" type="AcceptDialog" parent="Windows" unique_id=605735600]
 
-[node name="FileDialog" type="FileDialog" parent="Windows"]
+[node name="FileDialog" type="FileDialog" parent="Windows" unique_id=1161118336]
 mode = 2
 position = Vector2i(0, 36)
 

--- a/addons/escoria-wizard/item_creator.gd
+++ b/addons/escoria-wizard/item_creator.gd
@@ -96,13 +96,10 @@ func resize_image() -> void:
 	# Calculate the scale to make the preview as big as possible in the preview window depending on
 	# the height to width ratio of the frame
 	image_size = image_stream_texture.get_size()
+
 	var preview_scale = Vector2.ONE
-
-	var x_scale_ratio = preview_size.x / image_size.x
-	preview_scale.x = x_scale_ratio if x_scale_ratio < 1 else 1
-
-	var y_scale_ratio = preview_size.y / image_size.y
-	preview_scale.y = y_scale_ratio if y_scale_ratio < 1 else 1
+	preview_scale.x = CLAMP(preview_size.x / image_size.x, 0, 1)
+	preview_scale.y = CLAMP(preview_size.y / image_size.y, 0, 1);
 
 	if preview_scale.y > preview_scale.x:
 		get_node(PREVIEW_NODE).scale = Vector2(preview_scale.x, preview_scale.x)

--- a/addons/escoria-wizard/item_creator.gd
+++ b/addons/escoria-wizard/item_creator.gd
@@ -158,7 +158,7 @@ func _on_CreateButton_pressed() -> void:
 	var item = ESCItem.new()
 	item.name = get_node(ITEM_NAME_NODE).text
 	item.global_id = get_node(GLOBAL_ID_NODE).text
-	item.is_interactive = get_node(INTERACTIVE_NODE).pressed
+	item.is_interactive = get_node(INTERACTIVE_NODE).button_pressed
 	item.tooltip_name = get_node(ITEM_NAME_NODE).text
 
 	var selected_index = get_node(ACTION_NODE).selected

--- a/addons/escoria-wizard/item_creator.gd
+++ b/addons/escoria-wizard/item_creator.gd
@@ -98,8 +98,8 @@ func resize_image() -> void:
 	image_size = image_stream_texture.get_size()
 
 	var preview_scale = Vector2.ONE
-	preview_scale.x = clampi(preview_size.x / image_size.x, 0, 1)
-	preview_scale.y = clampi(preview_size.y / image_size.y, 0, 1)
+	preview_scale.x = clampf(preview_size.x / image_size.x, 0, 1)
+	preview_scale.y = clampf(preview_size.y / image_size.y, 0, 1)
 
 	if preview_scale.y > preview_scale.x:
 		get_node(PREVIEW_NODE).scale = Vector2(preview_scale.x, preview_scale.x)

--- a/addons/escoria-wizard/item_creator.gd
+++ b/addons/escoria-wizard/item_creator.gd
@@ -97,13 +97,13 @@ func resize_image() -> void:
 	# the height to width ratio of the frame
 	image_size = image_stream_texture.get_size()
 	var preview_scale = Vector2.ONE
-	
-	var x_scale_ratio = preview_size.x / image_size.x 
+
+	var x_scale_ratio = preview_size.x / image_size.x
 	preview_scale.x = x_scale_ratio if x_scale_ratio < 1 else 1
-	
+
 	var y_scale_ratio = preview_size.y / image_size.y
 	preview_scale.y = y_scale_ratio if y_scale_ratio < 1 else 1
-	
+
 	if preview_scale.y > preview_scale.x:
 		get_node(PREVIEW_NODE).scale = Vector2(preview_scale.x, preview_scale.x)
 	else:

--- a/addons/escoria-wizard/item_creator.gd
+++ b/addons/escoria-wizard/item_creator.gd
@@ -42,8 +42,12 @@ var preview_size:Vector2
 func _ready() -> void:
 	# Capture the size of the window before we update its contents so we have
 	# the absolute size before it gets scaled contents applied to it
-	preview_size = get_node(PREVIEW_NODE).size
+	preview_size = get_node(PREVIEW_NODE).get_size()
 	inventory_mode = not get_node(BACKGROUND_OBJ_NODE).pressed
+	
+	for option_list in ["look", "pick up", "open", "close", "use", "push", "pull", "talk"]:
+		get_node(ACTION_NODE).add_item(option_list)
+		
 	item_creator_reset()
 
 
@@ -52,14 +56,8 @@ func item_creator_reset() -> void:
 	get_node(GLOBAL_ID_NODE).text = ""
 	get_node(IMAGE_PATH_NODE).text = ""
 	get_node(INTERACTIVE_NODE).button_pressed = true
-
-	if get_node(ACTION_NODE).get_item_count() > 0:
-		get_node(ACTION_NODE).clear()
-
-		for option_list in ["look", "pick up", "open", "close", "use", "push", "pull", "talk"]:
-			get_node(ACTION_NODE).add_item(option_list)
-
 	get_node(ACTION_NODE).selected = 0
+
 	image_size = Vector2.ZERO
 	image_has_been_loaded = false
 	main_menu_requested = false
@@ -95,9 +93,13 @@ func resize_image() -> void:
 	# the height to width ratio of the frame
 	image_size = image_stream_texture.get_size()
 	var preview_scale = Vector2.ONE
-	preview_scale.x =  preview_size.x / image_size.x
-	preview_scale.y =  preview_size.y / image_size.y
-
+	
+	var x_scale_ratio = preview_size.x / image_size.x 
+	preview_scale.x = x_scale_ratio if x_scale_ratio < 1 else 1
+	
+	var y_scale_ratio = preview_size.y / image_size.y
+	preview_scale.y = y_scale_ratio if y_scale_ratio < 1 else 1
+	
 	if preview_scale.y > preview_scale.x:
 		get_node(PREVIEW_NODE).scale = Vector2(preview_scale.x, preview_scale.x)
 	else:
@@ -115,9 +117,11 @@ func load_button_pressed() -> void:
 func LoadObjectFileDialog_file_selected(path: String) -> void:
 	image_stream_texture = load(path)
 
+	resize_image()
+	
 	get_node(PREVIEW_NODE).texture = image_stream_texture
 
-	resize_image()
+	
 
 	get_node(IMAGE_SIZE_NODE).text = "(%s, %s)" % [image_size.x, image_size.y]
 

--- a/addons/escoria-wizard/item_creator.gd
+++ b/addons/escoria-wizard/item_creator.gd
@@ -39,16 +39,20 @@ var preview_size:Vector2
 
 
 # Called when the node enters the scene tree for the first time.
+
 func _ready() -> void:
 	# Capture the size of the window before we update its contents so we have
 	# the absolute size before it gets scaled contents applied to it
 	preview_size = get_node(PREVIEW_NODE).get_size()
 	inventory_mode = not get_node(BACKGROUND_OBJ_NODE).pressed
-	
-	for option_list in ["look", "pick up", "open", "close", "use", "push", "pull", "talk"]:
-		get_node(ACTION_NODE).add_item(option_list)
-		
+
+	var action_option: OptionButton = get_node(ACTION_NODE)
+	action_option.clear()
+	for option_list in ["", "look", "pick up", "open", "close", "use", "push", "pull", "talk"]:
+		action_option.add_item(option_list)
+
 	item_creator_reset()
+
 
 
 func item_creator_reset() -> void:
@@ -115,13 +119,18 @@ func load_button_pressed() -> void:
 
 
 func LoadObjectFileDialog_file_selected(path: String) -> void:
-	image_stream_texture = load(path)
+	var loaded_texture := load(path) as CompressedTexture2D
+	if loaded_texture == null:
+		get_node(ERROR_WINDOW_NODE).dialog_text = "Failed to load image: %s" % path
+		get_node(ERROR_WINDOW_NODE).popup_centered()
+		return
+	image_stream_texture = loaded_texture
 
 	resize_image()
-	
+
 	get_node(PREVIEW_NODE).texture = image_stream_texture
 
-	
+
 
 	get_node(IMAGE_SIZE_NODE).text = "(%s, %s)" % [image_size.x, image_size.y]
 

--- a/addons/escoria-wizard/item_creator.gd
+++ b/addons/escoria-wizard/item_creator.gd
@@ -98,8 +98,8 @@ func resize_image() -> void:
 	image_size = image_stream_texture.get_size()
 
 	var preview_scale = Vector2.ONE
-	preview_scale.x = CLAMP(preview_size.x / image_size.x, 0, 1)
-	preview_scale.y = CLAMP(preview_size.y / image_size.y, 0, 1);
+	preview_scale.x = clampi(preview_size.x / image_size.x, 0, 1)
+	preview_scale.y = clampi(preview_size.y / image_size.y, 0, 1)
 
 	if preview_scale.y > preview_scale.x:
 		get_node(PREVIEW_NODE).scale = Vector2(preview_scale.x, preview_scale.x)


### PR DESCRIPTION
Minimal fixes to make it work.
- Code fixes.
- Image resize fixed.
- Default action dropdown fixed.

Godot regenerates many ids... it's a bit noisy in the tscn file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scene layout updated with explicit node identifiers and clearer form/preview structure.
  * Separate preview areas for inventory and object images; file dialog title/position adjusted and inventory path button relabeled.

* **Bug Fixes**
  * Improved image preview scaling using independent clamped X/Y ratios.
  * Added error handling for failed image loads.
  * Fixed interactive-item detection to use the checkbox state.

* **Refactor**
  * Default action options populated at startup; item reset preserves actions and resets fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/godot-escoria/escoria-demo-game/pull/1242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->