### PR TITLE
chore: rename GAME_STATE

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/say.gd
@@ -103,14 +103,14 @@ func validate(arguments: Array):
 func run(command_params: Array) -> int:
 	var dict: Dictionary
 
-	escoria.current_state = escoria.GAME_STATE.DIALOG
+	escoria.current_state = escoria.GameState.DIALOG
 
 	if !escoria.dialog_player:
 		raise_error(
 			self,
 			"No dialog player was registered and the 'say' command was encountered."
 		)
-		escoria.current_state = escoria.GAME_STATE.DEFAULT
+		escoria.current_state = escoria.GameState.DEFAULT
 		return ESCExecution.RC_ERROR
 
 	if not escoria.main.current_scene.player:
@@ -119,7 +119,7 @@ func run(command_params: Array) -> int:
 			"[%s]: No player item in the current scene was registered and the say command was encountered."
 					% get_command_name()
 		)
-		escoria.current_state = escoria.GAME_STATE.DEFAULT
+		escoria.current_state = escoria.GameState.DEFAULT
 		return ESCExecution.RC_CANCEL
 
 	# Replace the names of any globals in "{ }" with their value
@@ -136,7 +136,7 @@ func run(command_params: Array) -> int:
 		command_params[2]
 	)
 	await escoria.dialog_player.say_finished
-	escoria.current_state = escoria.GAME_STATE.DEFAULT
+	escoria.current_state = escoria.GameState.DEFAULT
 	return ESCExecution.RC_OK
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/say.gd
@@ -13,8 +13,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SayCommand
+extends ESCBaseCommand
 
 ## The keyword used to refer to the current player
 const CURRENT_PLAYER_KEYWORD = "CURRENT_PLAYER"

--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -102,7 +102,7 @@ var action_state = ActionInputState.AWAITING_VERB_OR_ITEM:
 ## [br]
 ## Returns nothing.
 func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
-	if escoria.current_state == escoria.GAME_STATE.DEFAULT:
+	if escoria.current_state == escoria.GameState.DEFAULT:
 		match action:
 			ACTION.BACKGROUND_CLICK:
 				if can_interrupt:
@@ -235,9 +235,9 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 					self,
 					"Action received: '%s' with params %s." % [action, params]
 				)
-	elif escoria.current_state == escoria.GAME_STATE.WAIT:
+	elif escoria.current_state == escoria.GameState.WAIT:
 		pass
-	elif escoria.current_state == escoria.GAME_STATE.LOADING:
+	elif escoria.current_state == escoria.GameState.LOADING:
 		pass
 
 

--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -525,7 +525,7 @@ func _perform_script_events(room: ESCRoom) -> int:
 		script_transition_in.get_event_with_target(escoria.event_manager.EVENT_TRANSITION_IN)
 	)
 
-	if not escoria.current_state == escoria.GAME_STATE.LOADING:
+	if not escoria.current_state == escoria.GameState.LOADING:
 		var ready_event_added: bool = false
 		# Run the ready event, if there is one.
 		ready_event_added = _run_script_event(escoria.event_manager.EVENT_READY, room)

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
@@ -58,7 +58,7 @@ func run():
 		"Starting dialog."
 	)
 
-	escoria.current_state = escoria.GAME_STATE.DIALOG
+	escoria.current_state = escoria.GameState.DIALOG
 
 	if !escoria.dialog_player:
 		escoria.dialog_player = escoria.main.current_scene.get_node(
@@ -75,6 +75,6 @@ func run():
 	# If this is the case and the current level of dialog has a parent, it means
 	# it is still yielding and so will be shown again.
 
-	escoria.current_state = escoria.GAME_STATE.DEFAULT
+	escoria.current_state = escoria.GameState.DEFAULT
 
 	return option

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
@@ -1,6 +1,6 @@
 ## Represents a dialog in Escoria.
-extends ESCStatement
 class_name ESCDialog
+extends ESCStatement
 
 
 ## Avatar used in the dialog, if any.

--- a/addons/escoria-core/game/core-scripts/esc_background.gd
+++ b/addons/escoria-core/game/core-scripts/esc_background.gd
@@ -137,7 +137,7 @@ func _ready():
 ## [br]
 ## Returns nothing.
 func _unhandled_input(event: InputEvent) -> void:
-	var is_default_state = escoria.current_state == escoria.GAME_STATE.DEFAULT
+	var is_default_state = escoria.current_state == escoria.GameState.DEFAULT
 	if escoria.inputs_manager.try_custom_input_handler(event, is_default_state):
 		return
 	if not is_default_state:

--- a/addons/escoria-core/game/core-scripts/esc_background.gd
+++ b/addons/escoria-core/game/core-scripts/esc_background.gd
@@ -10,8 +10,8 @@
 ## is set over the whole scene, because its rect_size is then used to create the
 ## Area2D node under it. If the rect_size is wrongly set, the background may
 ## receive no input.
-extends TextureRect
 class_name ESCBackground
+extends TextureRect
 
 
 ## The background was double clicked[br]

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -543,7 +543,7 @@ func _unhandled_input(input_event: InputEvent) -> void:
 		event.position = get_global_mouse_position()
 
 	if event is InputEventMouseButton and event.is_pressed():
-		if not escoria.current_state == escoria.GAME_STATE.DEFAULT:
+		if not escoria.current_state == escoria.GameState.DEFAULT:
 			ESCSafeLogging.log_info(
 				self,
 				"Current game state doesn't accept interactions."

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -318,7 +318,7 @@ func load_game(id: int):
 		"Loading savegame %s" % str(id)
 	)
 	is_loading_game = true
-	escoria.current_state = escoria.GAME_STATE.LOADING
+	escoria.current_state = escoria.GameState.LOADING
 
 	var save_game: ESCSaveGame = ResourceLoader.load(save_file_path)
 
@@ -405,7 +405,7 @@ func load_game(id: int):
 	escoria.action_manager.clear_current_tool()
 	escoria.inputs_manager.input_mode = escoria.inputs_manager.INPUT_ALL
 	is_loading_game = false
-	escoria.current_state = escoria.GAME_STATE.DEFAULT
+	escoria.current_state = escoria.GameState.DEFAULT
 
 	emit_signal("game_finished_loading")
 

--- a/addons/escoria-core/game/esc_autoload.gd
+++ b/addons/escoria-core/game/esc_autoload.gd
@@ -24,7 +24,7 @@ signal resumed
 ## * DIALOG: Game is playing a dialog
 ## * WAIT: Game is waiting
 ## * LOADING: Game is currently loading
-enum GAME_STATE {
+enum GameState {
 	DEFAULT,
 	DIALOG,
 	WAIT,
@@ -149,8 +149,8 @@ var creating_new_game: bool = false
 	ProjectSettings.get_setting("display/window/size/viewport_width"),
 	ProjectSettings.get_setting("display/window/size/viewport_height"))
 
-## Current state of Escoria (GAME_STATE enum)
-@onready var current_state = GAME_STATE.DEFAULT
+## Current state of Escoria (GameState enum)
+@onready var current_state = GameState.DEFAULT
 
 ## Ready function. Instantiates the main scene if running a room directly.[br]
 ## [br]

--- a/addons/escoria-core/game/esc_autoload.gd
+++ b/addons/escoria-core/game/esc_autoload.gd
@@ -196,8 +196,7 @@ func get_escoria():
 	# We check if we run the full game or a room scene directly
 	if get_tree().current_scene is ESCMain:
 		return get_node("/root/main_scene").escoria_node
-	else:
-		return get_node("main_scene").escoria_node
+	return get_node("main_scene").escoria_node
 
 
 ## Pauses or unpause the game[br]

--- a/addons/escoria-core/game/esc_inputs_manager.gd
+++ b/addons/escoria-core/game/esc_inputs_manager.gd
@@ -43,7 +43,7 @@ var hotspot_focused: String = ""
 ## #### Parameters[br]
 ##[br]
 ## - event: The event to process[br]
-## - is_default_state: Whether the current state is escoria.GAME_STATE.DEFAULT[br]
+## - is_default_state: Whether the current state is escoria.GameState.DEFAULT[br]
 ##[br]
 ## **Returns** Whether the function processed the event.
 var custom_input_handler = null
@@ -138,7 +138,7 @@ func register_background(background: ESCBackground):
 ## [br]
 ## | Name | Type | Description | Required? |[br]
 ## |:-----|:-----|:------------|:----------|[br]
-## |callback|`Variant`|Function reference satisfying the above contract event The event to process is_default_state Whether the current state is escoria.GAME_STATE.DEFAULT returns whether the function processed the event `callback` is responsible for calling `get_tree().set_input_as_handled()`, if appropriate.|yes|[br]
+## |callback|`Variant`|Function reference satisfying the above contract event The event to process is_default_state Whether the current state is escoria.GameState.DEFAULT returns whether the function processed the event `callback` is responsible for calling `get_tree().set_input_as_handled()`, if appropriate.|yes|[br]
 ## [br]
 ## #### Returns[br]
 ## [br]
@@ -154,7 +154,7 @@ func register_custom_input_handler(callback) -> void:
 ## | Name | Type | Description | Required? |[br]
 ## |:-----|:-----|:------------|:----------|[br]
 ## |event|`InputEvent`|The event to process|yes|[br]
-## |is_default_state|`bool`|Whether the current state is escoria.GAME_STATE.DEFAULT|yes|[br]
+## |is_default_state|`bool`|Whether the current state is escoria.GameState.DEFAULT|yes|[br]
 ## [br]
 ## #### Returns[br]
 ## [br]

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -387,14 +387,14 @@ func show_ui():
 
 func hide_main_menu():
 	show_ui()
-	escoria.current_state = escoria.GAME_STATE.DEFAULT
+	escoria.current_state = escoria.GameState.DEFAULT
 	if get_node(main_menu).visible:
 		get_node(main_menu).hide()
 
 func show_main_menu():
-	if escoria.current_state == escoria.GAME_STATE.PAUSED:
+	if escoria.current_state == escoria.GameState.PAUSED:
 		return
-	escoria.current_state = escoria.GAME_STATE.PAUSED
+	escoria.current_state = escoria.GameState.PAUSED
 	hide_ui()
 	if not get_node(main_menu).visible:
 		get_node(main_menu).reset()
@@ -402,7 +402,7 @@ func show_main_menu():
 
 func unpause_game():
 	show_ui()
-	escoria.current_state = escoria.GAME_STATE.DEFAULT
+	escoria.current_state = escoria.GameState.DEFAULT
 	if get_node(pause_menu).visible:
 		get_node(pause_menu).hide()
 		escoria.object_manager.get_object(ESCObjectManager.SPEECH).node.resume()
@@ -411,10 +411,10 @@ func unpause_game():
 		escoria.set_game_paused(false)
 
 func pause_game():
-	if escoria.current_state == escoria.GAME_STATE.PAUSED:
+	if escoria.current_state == escoria.GameState.PAUSED:
 		return
 	show_ui()
-	escoria.current_state = escoria.GAME_STATE.PAUSED
+	escoria.current_state = escoria.GameState.PAUSED
 	if not get_node(pause_menu).visible:
 		get_node(main_menu).reset()
 		get_node(pause_menu).reset()

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -152,6 +152,8 @@ func _on_gamepad_disconnected():
 func _on_joy_connection_changed(device: int, connected: bool) -> void:
 	if device != JOY_DEVICE:
 		return
+
+	_is_gamepad_connected = connected
 	if connected:
 		_on_gamepad_connected()
 		return

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -1,10 +1,5 @@
 extends ESCGame
 
-
-const VERB_USE = "use"
-const VERB_WALK = "walk"
-
-
 """
 Implement methods to react to inputs.
 
@@ -42,6 +37,16 @@ Implement methods to react to inputs.
 - _on_event_done(event_name: String)
 """
 
+
+
+
+const VERB_USE = "use"
+const VERB_WALK = "walk"
+
+
+
+
+
 # Value to use for `device` argument to various `Input.get_joy` methods.
 const JOY_DEVICE = 0
 
@@ -64,14 +69,13 @@ const CHANGE_VERB_BUTTON = JOY_BUTTON_Y
 # Input action for use by InputMap
 const ESC_UI_CHANGE_VERB_ACTION = "esc_change_verb"
 
+var targeted_node: Node
+
 # true when a gamepad is connected.
 var _is_gamepad_connected = false
 
 # Tracks the mouse's current position onscreen.
 var _current_mouse_pos: Vector2 = Vector2.ZERO
-
-var targeted_node: Node
-
 
 func _ready():
 	hide_ui()
@@ -148,10 +152,11 @@ func _on_gamepad_disconnected():
 func _on_joy_connection_changed(device: int, connected: bool) -> void:
 	if device != JOY_DEVICE:
 		return
-	elif connected:
+	if connected:
 		_on_gamepad_connected()
-	else:
-		_on_gamepad_disconnected()
+		return
+
+	_on_gamepad_disconnected()
 
 
 func _process(_delta) -> void:
@@ -176,16 +181,18 @@ func _process_input(event: InputEvent, is_default_state: bool) -> bool:
 		# ESCBackground is not guaranteed to be set, as we may be on
 		# the "New Game" screen.
 		return false
-	elif _is_gamepad_connected and event is InputEventJoypadButton:
+
+	if _is_gamepad_connected and event is InputEventJoypadButton:
 		escoria.logger.trace(self, "InputEventJoypadButton: %s" % [event.as_text()])
 		if event.is_action_pressed(escoria.inputs_manager.ESC_UI_PRIMARY_ACTION):
 			# Admittedly, this breaks abstraction barriers and is completely
 			# inappropriate, but it's what works right now.
 			escoria.inputs_manager._on_left_click_on_bg(get_global_mouse_position())
 			return true
-		elif event.is_action_pressed(ESC_UI_CHANGE_VERB_ACTION):
-			mousewheel_action(1)
-			return true
+
+	if event.is_action_pressed(ESC_UI_CHANGE_VERB_ACTION):
+		mousewheel_action(1)
+		return true
 	return false
 
 
@@ -335,7 +342,7 @@ func right_click_on_inventory_item(inventory_item_global_id: String, event: Inpu
 	)
 
 
-func left_double_click_on_inventory_item(inventory_item_global_id: String, event: InputEvent) -> void:
+func left_double_click_on_inventory_item(_inventory_item_global_id: String, _event: InputEvent) -> void:
 	pass
 
 


### PR DESCRIPTION
- Rename `GAME_STATE` to `GameState`.
Fixes linter fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized game-state enum usage across engine, UI, input, dialog, action dispatch, room management, autoload, and save/load.
  * Reordered class/script declarations and streamlined input/gamepad/control flow for clearer early-return behavior.
* **Bug Fixes**
  * Explicitly reset game state on dialog completion, cancellations, and error paths to prevent stuck states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/godot-escoria/escoria-demo-game/pull/1244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->