### PR TITLE
chore: fix ui_library linter issues

### DIFF
--- a/addons/escoria-core/ui_library/inventory/esc_inventory_button.gd
+++ b/addons/escoria-core/ui_library/inventory/esc_inventory_button.gd
@@ -1,7 +1,7 @@
 ## The inventory representation of an ESC item if pickable (only used by
 ## the inventory components)
-extends TextureButton
 class_name ESCInventoryButton
+extends TextureButton
 
 ## Signal emitted when the item was left clicked.[br]
 ## [br]

--- a/addons/escoria-core/ui_library/inventory/esc_inventory_container.gd
+++ b/addons/escoria-core/ui_library/inventory/esc_inventory_container.gd
@@ -1,7 +1,7 @@
 
 ## Inventory container handler that acts as a base for UIs inventory containers.
-extends Control
 class_name ESCInventoryContainer
+extends Control
 
 ## Whether any item in the container is currently focused.[br]
 var item_focused: bool = false
@@ -85,7 +85,7 @@ func get_inventory_button(inventory_item: ESCInventoryItem) -> ESCInventoryButto
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func _on_inventory_item_focused(item_id):
+func _on_inventory_item_focused(_item_id):
 	item_focused = true
 
 

--- a/addons/escoria-core/ui_library/menus/load_save/save/save_game.gd
+++ b/addons/escoria-core/ui_library/menus/load_save/save/save_game.gd
@@ -29,9 +29,9 @@ func _on_slot_pressed(p_slot_n: int):
 
 # Create the slots from the list of savegames
 func refresh_savegames():
-	var _slots = $VBoxContainer/ScrollContainer/slots
-	for slot in _slots.get_children():
-		_slots.remove_child(slot)
+	var slots = $VBoxContainer/ScrollContainer/slots
+	for slot in slots.get_children():
+		slots.remove_child(slot)
 
 	var saves_list = escoria.save_manager.get_saves_list()
 
@@ -44,8 +44,8 @@ func refresh_savegames():
 		datetime["minute"],
 	]
 	var new_slot = slot_ui_scene.instantiate()
-	_slots.add_child(new_slot)
-	_slots.move_child(new_slot, 0)
+	slots.add_child(new_slot)
+	slots.move_child(new_slot, 0)
 	new_slot.set_slot_name_date(tr("New save"), datetime_string)
 	new_slot.connect("pressed", Callable(self, "_on_slot_pressed").bind(saves_list.size()+1))
 
@@ -56,7 +56,7 @@ func refresh_savegames():
 
 	for save in saves_array:
 		new_slot = slot_ui_scene.instantiate()
-		_slots.add_child(new_slot)
+		slots.add_child(new_slot)
 
 		datetime_string = "%02d/%02d/%02d %02d:%02d" % [
 			save.date["day"],

--- a/addons/escoria-core/ui_library/menus/load_save/save/save_game.gd
+++ b/addons/escoria-core/ui_library/menus/load_save/save/save_game.gd
@@ -32,6 +32,7 @@ func refresh_savegames():
 	var slots = $VBoxContainer/ScrollContainer/slots
 	for slot in slots.get_children():
 		slots.remove_child(slot)
+		slot.queue_free()
 
 	var saves_list = escoria.save_manager.get_saves_list()
 

--- a/addons/escoria-core/ui_library/menus/options/options.gd
+++ b/addons/escoria-core/ui_library/menus/options/options.gd
@@ -24,24 +24,24 @@ var _loaded_languages: Array = []
 
 # Initialize the flags
 func _ready() -> void:
-	var _flags_container: HBoxContainer = \
+	var flags_container: HBoxContainer = \
 			$VBoxContainer/MarginContainer/options/flags
-	for child in _flags_container.get_children():
-		_flags_container.remove_child(child)
+	for child in flags_container.get_children():
+		flags_container.remove_child(child)
 		child.queue_free()
 
 	_loaded_languages = []
 
-	for lang in TranslationServer.get_loaded_locales():
-		if not lang in _loaded_languages:
-			_loaded_languages.append(lang)
-			var _lang = TextureRect.new()
-			_lang.texture = load(
+	for language in TranslationServer.get_loaded_locales():
+		if not language in _loaded_languages:
+			_loaded_languages.append(language)
+			var language_item = TextureRect.new()
+			language_item.texture = load(
 				"res://addons/escoria-core/ui_library" + \
-				"/menus/options/flags/%s.png" % lang
+				"/menus/options/flags/%s.png" % language
 			)
-			_flags_container.add_child(_lang)
-			_lang.connect("gui_input", Callable(self, "_on_language_input").bind(lang))
+			flags_container.add_child(language_item)
+			language_item.connect("gui_input", Callable(self, "_on_language_input").bind(language))
 
 
 # Show the options
@@ -56,13 +56,13 @@ func show():
 # #### Parameters
 # - p_settings: The settings to use
 func initialize_options(p_settings):
-	var _options = $VBoxContainer/MarginContainer/options
-	_options.get_node("general_volume").value = p_settings["master_volume"]
-	_options.get_node("sound_volume").value = p_settings["sfx_volume"]
-	_options.get_node("music_volume").value = p_settings["music_volume"]
-	_options.get_node("speech_volume").value = p_settings["speech_volume"]
-	_options.get_node("ambient_volume").value = p_settings["ambient_volume"]
-	_options.get_node("fullscreen").set_pressed_no_signal(p_settings["fullscreen"])
+	var options = $VBoxContainer/MarginContainer/options
+	options.get_node("general_volume").value = p_settings["master_volume"]
+	options.get_node("sound_volume").value = p_settings["sfx_volume"]
+	options.get_node("music_volume").value = p_settings["music_volume"]
+	options.get_node("speech_volume").value = p_settings["speech_volume"]
+	options.get_node("ambient_volume").value = p_settings["ambient_volume"]
+	options.get_node("fullscreen").set_pressed_no_signal(p_settings["fullscreen"])
 
 
 # The language was changed


### PR DESCRIPTION
Fixed linter issues in the `addons/escoria-core/ui_library` folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization across inventory, save/load, and options menus: minor declaration and local variable renames, parameter renaming to unused, and internal slot-list handling changes — all implementation-only and preserving existing UI behavior, visuals, and user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->