### PR TITLE
chore: linter core scripts

### DIFF
--- a/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
+++ b/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
@@ -1,7 +1,7 @@
 ## Node that performs the moving (walk, teleport, terrain scaling...) actions on
 ## its parent node.
-extends Node
 class_name ESCMovable
+extends Node
 
 
 ## Tasks carried out by this walkable node[br]
@@ -623,5 +623,4 @@ func get_shortest_way_to_dir(current_dir: int, target_dir: int) -> int:
 	if internal and current_dir < target_dir or \
 			(not internal and current_dir > target_dir):
 		return 1
-	else:
-		return -1
+	return -1

--- a/addons/escoria-core/game/core-scripts/esc/commands/accept_input.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/accept_input.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name AcceptInputCommand
+extends ESCBaseCommand
 
 
 ## The list of supported input types

--- a/addons/escoria-core/game/core-scripts/esc/commands/anim.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/anim.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name AnimCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/anim_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/anim_block.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name AnimBlockCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/block_say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/block_say.gd
@@ -8,8 +8,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name BlockSayCommand
+extends ESCBaseCommand
 
 
 ## Constructor[br]
@@ -48,7 +48,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 ## #### Returns[br]
 ## [br]
 ## Returns True if the arguments are valid, false otherwise. (`bool`)
-func validate(arguments: Array):
+func validate(_arguments: Array):
 	return true
 
 
@@ -63,7 +63,7 @@ func validate(arguments: Array):
 ## #### Returns[br]
 ## [br]
 ## Returns the execution result code. (`int`)
-func run(command_params: Array) -> int:
+func run(_command_params: Array) -> int:
 	escoria.dialog_player.enable_preserve_dialog_box()
 	return ESCExecution.RC_OK
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
@@ -26,8 +26,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraPushCommand
+extends ESCCameraBaseCommand
 
 ## The list of supported transitions as per the link mentioned above
 const SUPPORTED_TRANSITIONS = ["LINEAR","SINE","QUINT","QUART","QUAD" ,"EXPO","ELASTIC","CUBIC",

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_push_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_push_block.gd
@@ -26,8 +26,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraPushBlockCommand
+extends ESCCameraBaseCommand
 
 
 ## The list of supported transitions as per the link mentioned above

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_limits.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_limits.gd
@@ -15,8 +15,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraSetLimitsCommand
+extends ESCCameraBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
@@ -12,8 +12,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraSetPosCommand
+extends ESCCameraBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos_block.gd
@@ -15,8 +15,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraSetPosBlockCommand
+extends ESCCameraBaseCommand
 
 
 # Tween for blocking

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
@@ -13,8 +13,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraSetTargetCommand
+extends ESCCameraBaseCommand
 
 
 ## Provides the argument descriptor that defines the command signature.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target_block.gd
@@ -17,8 +17,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraSetTargetBlockCommand
+extends ESCCameraBaseCommand
 
 
 # Tween for blocking

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
@@ -16,8 +16,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraSetZoomCommand
+extends ESCCameraBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_block.gd
@@ -20,8 +20,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraSetZoomBlockCommand
+extends ESCCameraBaseCommand
 
 
 var _camera_tween: Tween3

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name CameraSetZoomHeightCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height_block.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name CameraSetZoomHeightBlockCommand
+extends ESCBaseCommand
 
 
 ## Tween for blocking

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
@@ -20,8 +20,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraShiftCommand
+extends ESCCameraBaseCommand
 
 ## The list of supported transitions as per the link mentioned above
 const SUPPORTED_TRANSITIONS = ["LINEAR","SINE","QUINT","QUART","QUAD" ,"EXPO","ELASTIC","CUBIC",

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_shift_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_shift_block.gd
@@ -23,8 +23,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends ESCCameraBaseCommand
 class_name CameraShiftBlockCommand
+extends ESCCameraBaseCommand
 
 
 # The list of supported transitions as per the link mentioned above

--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name ChangeSceneCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene_godot.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene_godot.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name ChangeSceneGodotCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/custom.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/custom.gd
@@ -13,8 +13,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name CustomCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -54,7 +54,7 @@ func validate(arguments: Array):
 	if not escoria.object_manager.has(arguments[0]):
 		raise_invalid_object_error(self, arguments[0])
 		return false
-	elif not escoria.object_manager.get_object(arguments[0]).node.has_node(
+	if not escoria.object_manager.get_object(arguments[0]).node.has_node(
 		arguments[1]
 	):
 		raise_error(self, "Invalid node. Object with global id %s has no child node called %s."
@@ -63,7 +63,7 @@ func validate(arguments: Array):
 						arguments[1],
 					])
 		return false
-	elif not escoria.object_manager.get_object(arguments[0]).node\
+	if not escoria.object_manager.get_object(arguments[0]).node\
 		.get_node(
 			arguments[1]
 		)\

--- a/addons/escoria-core/game/core-scripts/esc/commands/dec_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/dec_global.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name DecGlobalCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/enable_terrain.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/enable_terrain.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name EnableTerrainCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -52,9 +52,8 @@ func run(command_params: Array) -> int:
 				new_active_navigation_instance
 		escoria.room_terrain.current_active_navigation_instance.enabled = true
 		return ESCExecution.RC_OK
-	else:
-		raise_error(self, "Can not find terrain node. Terrain node %s could not be found." % name)
-		return ESCExecution.RC_ERROR
+	raise_error(self, "Can not find terrain node. Terrain node %s could not be found." % name)
+	return ESCExecution.RC_ERROR
 
 
 ## Function called when the command is interrupted.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/end_block_say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/end_block_say.gd
@@ -8,8 +8,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name EndBlockSayCommand
+extends ESCBaseCommand
 
 
 ## Constructor (bypasses the default constructor to avoid)[br]
@@ -49,7 +49,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 ## #### Returns[br]
 ## [br]
 ## Returns True if the arguments are valid, false otherwise. (`bool`)
-func validate(arguments: Array):
+func validate(_arguments: Array):
 	return true
 
 
@@ -64,7 +64,7 @@ func validate(arguments: Array):
 ## #### Returns[br]
 ## [br]
 ## Returns the execution result code. (`int`)
-func run(command_params: Array) -> int:
+func run(_command_params: Array) -> int:
 	escoria.dialog_player.disable_preserve_dialog_box()
 	return ESCExecution.RC_OK
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/hide_menu.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/hide_menu.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name HideMenuCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -69,7 +69,7 @@ func run(command_params: Array) -> int:
 	# Transition out from menu
 	transition_id = escoria.main.scene_transition.transition(
 		"",
-		ESCTransitionPlayer.TRANSITION_MODE.OUT
+		ESCTransitionPlayer.TransitionMode.OUT
 	)
 
 	if transition_id != ESCTransitionPlayer.TRANSITION_ID_INSTANT:

--- a/addons/escoria-core/game/core-scripts/esc/commands/inc_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/inc_global.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name IncGlobalCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/inventory_add.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/inventory_add.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name InventoryAddCommand
+extends ESCBaseCommand
 
 
 ## List of illegal strings that cannot be used in item names.

--- a/addons/escoria-core/game/core-scripts/esc/commands/inventory_remove.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/inventory_remove.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name InventoryRemoveCommand
+extends ESCBaseCommand
 
 ## List of illegal strings that cannot be used in item names.
 const ILLEGAL_STRINGS = ["/"]

--- a/addons/escoria-core/game/core-scripts/esc/commands/play_snd.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/play_snd.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name PlaySndCommand
+extends ESCBaseCommand
 
 
 ## The specified sound player

--- a/addons/escoria-core/game/core-scripts/esc/commands/print_internal.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/print_internal.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name PrintCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/queue_resource.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/queue_resource.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name QueueResourceCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/rand_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/rand_global.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name RandGlobalCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/repeat.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/repeat.gd
@@ -8,8 +8,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name RepeatCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -40,7 +40,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 ## #### Returns[br]
 ## [br]
 ## Returns the execution result code. (`int`)
-func run(command_params: Array) -> int:
+func run(_command_params: Array) -> int:
 	return ESCExecution.RC_CANCEL
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/save_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/save_game.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SaveGameCommand
+extends ESCBaseCommand
 
 
 ## Constructor[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_active.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_active.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetActiveCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_active_if_exists.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_active_if_exists.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetActiveIfExistsCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_angle.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_angle.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetAngleCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_direction.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_direction.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetDirectionCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -55,14 +55,14 @@ func validate(arguments: Array):
 					% [get_command_name(), arguments[0]]
 		)
 		return false
-	elif not escoria.object_manager.get_object(arguments[0]).node.is_movable:
+	if not escoria.object_manager.get_object(arguments[0]).node.is_movable:
 		escoria.logger.error(
 			self,
 			"[%s]: invalid object. Object with global id %s is not movable."
 					% [get_command_name(), arguments[0]]
 		)
 		return false
-	elif arguments[1] < 0 or arguments[1] > escoria.object_manager.get_object(arguments[0]).node \
+	if arguments[1] < 0 or arguments[1] > escoria.object_manager.get_object(arguments[0]).node \
 			.get_directions_quantity() - 1:
 		escoria.logger.error(
 			self,

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_global.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetGlobalCommand
+extends ESCBaseCommand
 
 ## The list of illegal strings that cannot be used in global names.
 const ILLEGAL_STRINGS = ["/"]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_globals.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_globals.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetGlobalsCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_gui_visible.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_gui_visible.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetGuiVisibleCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_interactive.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_interactive.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetInteractiveCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_item_custom_data.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_item_custom_data.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetItemCustomDataCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_state.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_state.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SetStateCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/show_menu.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/show_menu.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name ShowMenuCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -73,7 +73,7 @@ func run(command_params: Array) -> int:
 	# Transition out from current scene
 	var transition_id = escoria.main.scene_transition.transition(
 		"",
-		ESCTransitionPlayer.TRANSITION_MODE.OUT
+		ESCTransitionPlayer.TransitionMode.OUT
 	)
 
 	if transition_id != ESCTransitionPlayer.TRANSITION_ID_INSTANT:

--- a/addons/escoria-core/game/core-scripts/esc/commands/slide.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/slide.gd
@@ -14,8 +14,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SlideCommand
+extends ESCBaseCommand
 
 
 ## A hash of tweens currently active for animated items

--- a/addons/escoria-core/game/core-scripts/esc/commands/slide_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/slide_block.gd
@@ -13,8 +13,8 @@
 ##
 ## @ASHES
 ## @COMMAND
-extends SlideCommand
 class_name SlideBlockCommand
+extends SlideCommand
 
 
 ## Runs the command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/spawn.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/spawn.gd
@@ -13,8 +13,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name SpawnCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/stop.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/stop.gd
@@ -8,8 +8,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name StopCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -40,7 +40,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 ## #### Returns[br]
 ## [br]
 ## Returns the execution result code. (`int`)
-func run(command_params: Array) -> int:
+func run(_command_params: Array) -> int:
 	return ESCExecution.RC_CANCEL
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/stop_snd.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/stop_snd.gd
@@ -10,16 +10,14 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name StopSndCommand
-
-
-## The specified sound player
-var _snd_player: String
+extends ESCBaseCommand
 
 ## The previous sound state, saved for interrupting
 var previous_snd_state: String
 
+## The specified sound player
+var _snd_player: String
 
 ## The descriptor of the arguments of this command.[br]
 ## [br]
@@ -93,20 +91,20 @@ func run(command_params: Array) -> int:
 ## [br]
 ## Returns nothing.
 func interrupt():
-	var _sound_players = []
+	var sound_players = []
 	if previous_snd_state.is_empty():
 		previous_snd_state = "off"
 
 	if _snd_player.is_empty():
-		_sound_players = [
+		sound_players = [
 			ESCObjectManager.MUSIC,
 			ESCObjectManager.SOUND,
 			ESCObjectManager.SPEECH
 		]
 	else:
-		_sound_players = [_snd_player]
+		sound_players = [_snd_player]
 
-	for snd_player in _sound_players:
+	for snd_player in sound_players:
 		if escoria.object_manager.get_object(snd_player).node:
 			escoria.object_manager.get_object(snd_player).node.set_state(
 				previous_snd_state

--- a/addons/escoria-core/game/core-scripts/esc/commands/teleport.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/teleport.gd
@@ -11,8 +11,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name TeleportCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/teleport_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/teleport_pos.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name TeleportPosCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/transition.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/transition.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name TransitionCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]
@@ -78,8 +78,8 @@ func validate(arguments: Array):
 func run(command_params: Array) -> int:
 	var transition_id = escoria.main.scene_transition.transition(
 		command_params[0],
-		ESCTransitionPlayer.TRANSITION_MODE.OUT if command_params[1] == "out" \
-				else ESCTransitionPlayer.TRANSITION_MODE.IN,
+		ESCTransitionPlayer.TransitionMode.OUT if command_params[1] == "out" \
+				else ESCTransitionPlayer.TransitionMode.IN,
 		command_params[2]
 	)
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/turn_to.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/turn_to.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name TurnToCommand
+extends ESCBaseCommand
 
 
 ## The descriptor of the arguments of this command.[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/wait.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/wait.gd
@@ -10,8 +10,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name WaitCommand
+extends ESCBaseCommand
 
 ## Timer to wait for
 var timer: Timer

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name WalkCommand
+extends ESCBaseCommand
 
 
 ## Walking object

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk_block.gd
@@ -12,8 +12,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name WalkBlockCommand
+extends ESCBaseCommand
 
 
 ## Walking object

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos.gd
@@ -13,8 +13,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name WalkToPosCommand
+extends ESCBaseCommand
 
 
 ## Walking object
@@ -56,7 +56,7 @@ func validate(arguments: Array):
 	if not escoria.object_manager.has(arguments[0]):
 		raise_error(
 			self,
-			 "Invalid first object. The object to make walk with global id '%s' was not found." % arguments[0]
+			"Invalid first object. The object to make walk with global id '%s' was not found." % arguments[0]
 		)
 		return false
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos_block.gd
@@ -13,8 +13,8 @@
 ## [br]
 ## @ASHES
 ## @COMMAND
-extends ESCBaseCommand
 class_name WalkToPosBlockCommand
+extends ESCBaseCommand
 
 
 ## Walking object

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_environment.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_environment.gd
@@ -2,8 +2,8 @@
 ##
 ## Scoping is implemented using this class, including traditional scoping rules.
 ## Scope binding and resolution are handled in this class.
-extends Object
 class_name ESCEnvironment
+extends Object
 
 
 var _enclosing: # ESCEnvironment

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_grammar_expr.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_grammar_expr.gd
@@ -3,8 +3,8 @@
 ## All inheriting classes must implement an `accept` method to invoke the visitor.
 ## For more information on the "Visitor" pattern, see:
 ## (Visitor Pattern)[https://en.wikipedia.org/wiki/Visitor_pattern]
-extends RefCounted
 class_name ESCGrammarExpr
+extends RefCounted
 
 
 ## Method that invokes another method in the visitor against this, the implementing class.[br]
@@ -18,5 +18,5 @@ class_name ESCGrammarExpr
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func accept(visitor):
+func accept(_visitor):
 	pass

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_grammar_stmt.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_grammar_stmt.gd
@@ -3,8 +3,8 @@
 ## All inheriting classes must implement an `accept` method to invoke the visitor.
 ## For more information on the "Visitor" pattern, see:
 ## (Visitor Pattern)[https://en.wikipedia.org/wiki/Visitor_pattern]
-extends RefCounted
 class_name ESCGrammarStmt
+extends RefCounted
 
 
 ## Method that invokes another method in the visitor against this, the implementing class.[br]
@@ -18,5 +18,5 @@ class_name ESCGrammarStmt
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func accept(visitor):
+func accept(_visitor):
 	pass

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_parse_error.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_parse_error.gd
@@ -1,3 +1,3 @@
 ## Class to represent an error that occured during parsing.
-extends Object
 class_name ESCParseError
+extends Object

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_resolver.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_resolver.gd
@@ -1,8 +1,8 @@
 ## Resolves script variables to ensure that scoping rules are obeyed.
 ##
 ## The class will throw errors if scoping rules are broken or otherwise not followed.
-extends RefCounted
 class_name ESCResolver
+extends RefCounted
 
 
 var _interpreter
@@ -136,7 +136,7 @@ func visit_while_stmt(stmt: ESCGrammarStmts.While):
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func visit_pass_stmt(stmt: ESCGrammarStmts.Pass):
+func visit_pass_stmt(_stmt: ESCGrammarStmts.Pass):
 	pass
 
 
@@ -151,7 +151,7 @@ func visit_pass_stmt(stmt: ESCGrammarStmts.Pass):
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func visit_stop_stmt(stmt: ESCGrammarStmts.Stop):
+func visit_stop_stmt(_stmt: ESCGrammarStmts.Stop):
 	pass
 
 
@@ -186,7 +186,7 @@ func visit_var_stmt(stmt: ESCGrammarStmts.Var):
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func visit_global_stmt(stmt: ESCGrammarStmts.Global):
+func visit_global_stmt(_stmt: ESCGrammarStmts.Global):
 	pass
 
 
@@ -237,7 +237,7 @@ func visit_break_stmt(stmt: ESCGrammarStmts.Break):
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func visit_done_stmt(stmt: ESCGrammarStmts.Done):
+func visit_done_stmt(_stmt: ESCGrammarStmts.Done):
 	pass
 
 
@@ -270,7 +270,7 @@ func visit_dialog_stmt(stmt: ESCGrammarStmts.Dialog):
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func visit_literal_expr(expr: ESCGrammarExprs.Literal):
+func visit_literal_expr(_expr: ESCGrammarExprs.Literal):
 	pass
 
 

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_scanner.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_scanner.gd
@@ -3,8 +3,8 @@
 ## This is the first link in the ASHES compiler toolchain, and takes in ASHES
 ## script as text in order to provide a list of tokens to be handled by the
 ## ASHES parser.
-extends RefCounted
 class_name ESCScanner
+extends RefCounted
 
 
 ## In ASHES, an identifier starting with `$` is interpreted as a lookup in

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_script_builder.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_script_builder.gd
@@ -1,7 +1,7 @@
 ## Convenience class to help build scripts in code for use with the ASHES compiler
 ## toolchain. Loosely follows the Builder pattern.
-extends RefCounted
 class_name ESCScriptBuilder
+extends RefCounted
 
 
 # Not really a "Builder" pattern per se, but helps with readability.

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_token.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_token.gd
@@ -3,11 +3,11 @@
 ##
 ## This class contains any information required by the parser but also carries
 ## with it associated information useful for debugging and tracing purposes.
-extends RefCounted
 class_name ESCToken
+extends RefCounted
 
 
-var _tokenType: int: # ESCScanner.TokenType enum
+var _token_type: int: # ESCScanner.TokenType enum
 	get = get_type
 var _lexeme: String:
 	get = get_lexeme
@@ -38,8 +38,8 @@ var _filename: String:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func init(tokenType: int, lexeme: String, literal, source: String, line: int, filename: String) -> void:
-	_tokenType = tokenType
+func init(token_type: int, lexeme: String, literal, source: String, line: int, filename: String) -> void:
+	_token_type = token_type
 	_lexeme = lexeme
 	_literal = literal
 	_source = source
@@ -85,7 +85,7 @@ func get_source() -> String:
 ## [br]
 ## Returns the type of token this is; will be a value from `ESCTokenType.TokenType`. (`int`)
 func get_type() -> int:
-	return _tokenType
+	return _token_type
 
 
 ## The literal value of the token, if it exists.[br]
@@ -141,4 +141,4 @@ func get_filename() -> String:
 
 
 func _to_string() -> String:
-	return ESCTokenType.get_token_type_name(_tokenType) + " " + str(_lexeme) + " " + (str(_literal) if _literal else "")
+	return ESCTokenType.get_token_type_name(_token_type) + " " + str(_lexeme) + " " + (str(_literal) if _literal else "")

--- a/addons/escoria-core/game/core-scripts/esc/esc_command_registry.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_command_registry.gd
@@ -1,6 +1,6 @@
 ## A registry of ASHES command objects.
-extends RefCounted
 class_name ESCCommandRegistry
+extends RefCounted
 
 
 ## The registry of registered commands.
@@ -54,5 +54,4 @@ func load_command(command_name: String) -> ESCBaseCommand:
 func is_command_or_control_pressed(command_name: String) -> ESCBaseCommand:
 	if self.registry.has(command_name):
 		return self.registry[command_name]
-	else:
-		return self.load_command(command_name)
+	return self.load_command(command_name)

--- a/addons/escoria-core/game/core-scripts/esc/esc_inventory_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_inventory_manager.gd
@@ -1,7 +1,7 @@
 ## A manager for inventory objects.
 ## @MANAGER
-extends Resource
 class_name ESCInventoryManager
+extends Resource
 
 
 ## Checks whether the player has an inventory item.[br]

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
@@ -1,8 +1,8 @@
 ## Abstract base class for every ESC command.
 ##
 ## Extending classes have to override the configure and run function
-extends Resource
 class_name ESCBaseCommand
+extends Resource
 
 
 ## The filename from which the relevant command is being called, if available.
@@ -60,7 +60,7 @@ func validate(arguments: Array) -> bool:
 ## #### Returns[br]
 ## [br]
 ## Returns a `int` value. (`int`)
-func run(command_params: Array) -> int:
+func run(_command_params: Array) -> int:
 	raise_error(self, "Command %s did not override run. Please implement a run() function." % get_command_name())
 
 	return 0

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_camera_base_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_camera_base_command.gd
@@ -6,8 +6,8 @@
 ## [br]
 ## None.
 ## [br]
-extends ESCBaseCommand
 class_name ESCCameraBaseCommand
+extends ESCBaseCommand
 
 
 ## Generates a log entry when attempting to move the camera to an invalid position.[br]

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command_argument_descriptor.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command_argument_descriptor.gd
@@ -1,6 +1,6 @@
 ## Describes the arguments of commands that extend `ESCBaseCommand`.
-extends RefCounted
 class_name ESCCommandArgumentDescriptor
+extends RefCounted
 
 
 ## As the get_type command was deprecated with Godot 2.x w we need a way to determine

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_event.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_event.gd
@@ -12,18 +12,8 @@
 ##    run once the room is visible.[br]
 ## - `:use <global id>` : Called from the current item when it is used with the item
 ##   with specified by `<global id>`.
-extends ESCStatement
 class_name ESCEvent
-
-## Regex identifying an ESC event.
-const REGEX = \
-	'^:(?<name>[^|]+)( \\|\\s*(?<flags>( ' + \
-	'(TK|NO_TT|NO_UI|NO_SAVE)' + \
-	')+))?$'
-
-## Prefix to identify this as an ESC event.
-const PREFIX = ":"
-
+extends ESCStatement
 
 ## Valid event flags:[br]
 ## - `TK`: stands for "telekinetic". It means the player won't walk over to
@@ -43,6 +33,14 @@ enum FLAGS {
 	NO_SAVE = 8
 }
 
+## Regex identifying an ESC event.
+const REGEX = \
+	'^:(?<name>[^|]+)( \\|\\s*(?<flags>( ' + \
+	'(TK|NO_TT|NO_UI|NO_SAVE)' + \
+	')+))?$'
+
+## Prefix to identify this as an ESC event.
+const PREFIX = ":"
 
 ## Name of the event.
 var name: String

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_execution.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_execution.gd
@@ -1,6 +1,6 @@
 ## Class with enum containing the return codes returned by ASHES script functions.
-extends Resource
 class_name ESCExecution
+extends Resource
 ## Execution result values.
 
 ## Return codes handled by events.[br]

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_room_container.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_room_container.gd
@@ -1,7 +1,7 @@
 ## Abstract base class for a container of Escoria entities specific to a room
 ## to be stored in and used by the Escoria object manager.
-extends RefCounted
 class_name ESCRoomContainer
+extends RefCounted
 
 
 ## Designates whether the objects contained in this container are all reserved objects.

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_room_objects.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_room_objects.gd
@@ -1,6 +1,6 @@
 ## Container for a room's `ESCObject`s stored in the object manager.
-extends ESCRoomContainer
 class_name ESCRoomObjects
+extends ESCRoomContainer
 
 
 ## The hash of objects registered to the room.

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_room_objects_key.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_room_objects_key.gd
@@ -1,7 +1,7 @@
 ## Simple pair container to store a room's identifying information for use in
 ## the object manager.
-extends RefCounted
 class_name ESCRoomObjectsKey
+extends RefCounted
 
 
 ## Contains the `global_id` of the room being represented by this key.

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_room_terrains.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_room_terrains.gd
@@ -1,6 +1,6 @@
 ## Container for `NavigationPolygon`s stored in the object manager.
-extends ESCRoomContainer
 class_name ESCRoomTerrains
+extends ESCRoomContainer
 
 
 ## The hash of terrains registered to the room.

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_scheduled_event.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_scheduled_event.gd
@@ -1,6 +1,6 @@
 ## Represents an event that is scheduled to run sometime in the future.
-extends RefCounted
 class_name ESCScheduledEvent
+extends RefCounted
 
 
 ## The event to run when timeout is reached.

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_statement.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_statement.gd
@@ -5,8 +5,8 @@
 ## newer ASHES scripting language used by Escoria. Although this class is extended
 ## to facilitate the execution of actual commands and dialogs, the name may be
 ## a bit misleading and may eventually be renamed or refactored.
-extends RefCounted
 class_name ESCStatement
+extends RefCounted
 
 
 ## Emitted when the event has finished running.[br]
@@ -136,7 +136,7 @@ func run() -> int:
 			)
 			if rc == ESCExecution.RC_REPEAT:
 				return await self.run()
-			elif rc != ESCExecution.RC_OK:
+			if rc != ESCExecution.RC_OK:
 				final_rc = rc
 				current_statement.is_completed = true
 				break

--- a/addons/escoria-core/game/core-scripts/esc_animation_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_animation_player.gd
@@ -1,7 +1,7 @@
 ## An abstraction class to expose the same animation methods for both
 ## AnimatedSprite and AnimationPlayer.
-extends Node
 class_name ESCAnimationPlayer
+extends Node
 
 
 ## Signal emitted when the animation finished playing.[br]
@@ -80,8 +80,7 @@ func _ready() -> void:
 func get_animation() -> String:
 	if _is_animation_player:
 		return _animation_player.assigned_animation
-	else:
-		return _animated_sprite.animation
+	return _animated_sprite.animation
 
 
 ## A list of all animation names.[br]
@@ -96,8 +95,7 @@ func get_animation() -> String:
 func get_animations() -> PackedStringArray:
 	if _is_animation_player:
 		return _animation_player.get_animation_list()
-	else:
-		return _animated_sprite.sprite_frames.get_animation_names()
+	return _animated_sprite.sprite_frames.get_animation_names()
 
 
 ## Whether the animation is playing.[br]
@@ -187,8 +185,7 @@ func play_backwards(name: String):
 func has_animation(name: String) -> bool:
 	if _is_animation_player:
 		return _animation_player.has_animation(name)
-	else:
-		return _animated_sprite.sprite_frames.has_animation(name)
+	return _animated_sprite.sprite_frames.has_animation(name)
 
 
 ## Play an animation and directly skip to the end.[br]
@@ -225,9 +222,9 @@ func seek_end(name: String):
 func get_length(name: String) -> float:
 	if _is_animation_player:
 		return _animation_player.get_animation(name).length
-	else:
-		return _animated_sprite.sprite_frames.get_frame_count(name) - 1 * \
-				_animated_sprite.sprite_frames.get_animation_speed(name)
+
+	return _animated_sprite.sprite_frames.get_frame_count(name) - 1 * \
+		_animated_sprite.sprite_frames.get_animation_speed(name)
 
 
 ## Return true if the ESCAnimationPlayer node is valid, ie. it has a valid player node.[br]
@@ -257,7 +254,7 @@ func is_valid() -> bool:
 func _on_animation_finished(name: String):
 	if _is_animation_player and not _animation_player.get_animation(name).loop_mode != Animation.LOOP_NONE:
 		_animation_player.stop(true) # param here is to keep current state and
-									 # avoid resetting animation position to 0
+									# avoid resetting animation position to 0
 	elif not _animated_sprite.sprite_frames.get_animation_loop(name):
 		_animated_sprite.stop()
 	animation_finished.emit(name)

--- a/addons/escoria-core/game/core-scripts/esc_dialog_location.gd
+++ b/addons/escoria-core/game/core-scripts/esc_dialog_location.gd
@@ -5,8 +5,8 @@
 ## automatically use an `ESCLocation` that is a child of the destination node.
 ## Commands like `turn_to`--which are not movement-based--will ignore child
 ## `ESCLocation`s and refer to the parent node.
-extends ESCLocation
 class_name ESCDialogLocation
+extends ESCLocation
 
 
 ## Whether this object's class is the same as given string class name.[br]

--- a/addons/escoria-core/game/core-scripts/esc_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc_game.gd
@@ -1,8 +1,8 @@
 ## Base class for ESC game scenes
 ## An extending class can be used in the project settings and is responsible
 ## for managing very basic game features and controls
-extends Node2D
 class_name ESCGame
+extends Node2D
 
 
 ## Signal emitted when the user has confirmed the crash popup[br]
@@ -25,7 +25,7 @@ signal request_pause_menu
 ## Editor debug modes[br]
 ## NONE - No debugging[br]
 ## MOUSE_TOOLTIP_LIMITS - Visualize the tooltip limits
-enum EDITOR_GAME_DEBUG_DISPLAY {
+enum EditorGameDebugDisplay {
 	NONE, # No debugging
 	MOUSE_TOOLTIP_LIMITS # Visualize the tooltip limits
 }
@@ -41,7 +41,7 @@ enum EDITOR_GAME_DEBUG_DISPLAY {
 @export var mouse_tooltip_margin: float = 50.0
 
 ## Debug mode for the editor (None, Mouse Tooltips Limit)
-@export var editor_debug_mode: EDITOR_GAME_DEBUG_DISPLAY = EDITOR_GAME_DEBUG_DISPLAY.NONE:
+@export var editor_debug_mode: EditorGameDebugDisplay = EditorGameDebugDisplay.NONE:
 	set = _set_editor_debug_mode
 
 ## The Control node underneath which all UI must be placed.
@@ -143,10 +143,10 @@ func _ready():
 func _draw():
 	if not Engine.is_editor_hint():
 		return
-	if editor_debug_mode == EDITOR_GAME_DEBUG_DISPLAY.NONE:
+	if editor_debug_mode == EditorGameDebugDisplay.NONE:
 		return
 
-	if editor_debug_mode == EDITOR_GAME_DEBUG_DISPLAY.MOUSE_TOOLTIP_LIMITS:
+	if editor_debug_mode == EditorGameDebugDisplay.MOUSE_TOOLTIP_LIMITS:
 		var mouse_limits: Rect2 = get_viewport_rect().grow(
 			-mouse_tooltip_margin
 		)
@@ -319,7 +319,7 @@ func left_double_click_on_bg(position: Vector2) -> void:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func element_focused(element_id: String) -> void:
+func element_focused(_element_id: String) -> void:
 	pass
 
 
@@ -412,8 +412,8 @@ func left_double_click_on_item(
 ## [br]
 ## Returns nothing.
 func left_click_on_inventory_item(
-	inventory_item_global_id: String,
-	event: InputEvent
+	_inventory_item_global_id: String,
+	_event: InputEvent
 ) -> void:
 	pass
 
@@ -431,8 +431,8 @@ func left_click_on_inventory_item(
 ## [br]
 ## Returns nothing.
 func right_click_on_inventory_item(
-	inventory_item_global_id: String,
-	event: InputEvent
+	_inventory_item_global_id: String,
+	_event: InputEvent
 ) -> void:
 	pass
 
@@ -450,8 +450,8 @@ func right_click_on_inventory_item(
 ## [br]
 ## Returns nothing.
 func left_double_click_on_inventory_item(
-	inventory_item_global_id: String,
-	event: InputEvent
+	_inventory_item_global_id: String,
+	_event: InputEvent
 ) -> void:
 	pass
 
@@ -467,7 +467,7 @@ func left_double_click_on_inventory_item(
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func inventory_item_focused(inventory_item_global_id: String) -> void:
+func inventory_item_focused(_inventory_item_global_id: String) -> void:
 	pass
 
 
@@ -521,7 +521,7 @@ func close_inventory():
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func mousewheel_action(direction: int):
+func mousewheel_action(_direction: int):
 	pass
 
 
@@ -557,7 +557,7 @@ func show_ui():
 ## [br]
 ## | Name | Type | Description | Required? |[br]
 ## |:-----|:-----|:------------|:----------|[br]
-## |p_editor_debug_mode|`int`|EDITOR_GAME_DEBUG_DISPLAY enum (int) value corresponding to the desired editor debug mode|yes|[br]
+## |p_editor_debug_mode|`int`|EditorGameDebugDisplay enum (int) value corresponding to the desired editor debug mode|yes|[br]
 ## [br]
 ## #### Returns[br]
 ## [br]
@@ -659,7 +659,7 @@ func hide_main_menu():
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func apply_custom_settings(custom_settings: Dictionary):
+func apply_custom_settings(_custom_settings: Dictionary):
 	pass
 
 

--- a/addons/escoria-core/game/core-scripts/esc_interaction_location.gd
+++ b/addons/escoria-core/game/core-scripts/esc_interaction_location.gd
@@ -5,8 +5,8 @@
 ## automatically use an `ESCLocation` that is a child of the destination node.[br]
 ## Commands like `turn_to`--which are not movement-based--will ignore child
 ## `ESCLocation`s and refer to the parent node.
-extends ESCLocation
 class_name ESCInteractionLocation
+extends ESCLocation
 
 ## Whether this object's class is the same as given string class name.[br]
 ## [br]

--- a/addons/escoria-core/game/core-scripts/esc_location.gd
+++ b/addons/escoria-core/game/core-scripts/esc_location.gd
@@ -5,8 +5,8 @@
 ## automatically use an `ESCLocation` that is a child of the destination node.
 ## Commands like `turn_to`--which are not movement-based--will ignore child
 ## `ESCLocation`s and refer to the parent node.
-extends Marker2D
 class_name ESCLocation
+extends Marker2D
 
 
 ## Escoria Plugin signal emitted to the `ESCRoom` when a start location is set in the `ESCLocation` node in order to check whether multiple start locations are set.[br]

--- a/addons/escoria-core/game/core-scripts/esc_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_player.gd
@@ -1,8 +1,8 @@
 @tool
 @icon("res://addons/escoria-core/design/esc_player.svg")
 ## An Escoria playable character.
-extends ESCItem
 class_name ESCPlayer
+extends ESCItem
 
 
 ## Whether the player can be hovered over and actions performed on like an item.

--- a/addons/escoria-core/game/core-scripts/esc_resource_cache.gd
+++ b/addons/escoria-core/game/core-scripts/esc_resource_cache.gd
@@ -1,6 +1,6 @@
 ## A cache for resources
-extends Node
 class_name ESCResourceCache
+extends Node
 
 
 signal resource_loading_progress(path, progress)
@@ -23,7 +23,7 @@ func queue_resource(path: String, p_in_front: bool = false, p_permanent: bool = 
 	if path in pending:
 		return
 
-	elif ResourceLoader.has_cached(path):
+	if ResourceLoader.has_cached(path):
 		var res = ResourceLoader.load(path)
 		pending[path] = ESCResourceDescriptor.new(res, p_permanent)
 	else:
@@ -102,20 +102,19 @@ func get_resource(path):
 
 			return res
 
-		else:
-			var res = pending[path].res
-			if !pending[path].permanent:
-				pending.erase(path)
+		var res = pending[path].res
+		if !pending[path].permanent:
+			pending.erase(path)
 
-			return res
-	else:
-		# We can't use ESCProjectSettingsManager here since this method
-		# can be called from escoria._init()
-		if not ProjectSettings.get_setting("escoria/platform/skip_cache"):
-			var res = ResourceLoader.load(path)
-			pending[path] = ESCResourceDescriptor.new(res, true)
-			return res
-		return ResourceLoader.load(path)
+		return res
+
+	# We can't use ESCProjectSettingsManager here since this method
+	# can be called from escoria._init()
+	if not ProjectSettings.get_setting("escoria/platform/skip_cache"):
+		var res = ResourceLoader.load(path)
+		pending[path] = ESCResourceDescriptor.new(res, true)
+		return res
+	return ResourceLoader.load(path)
 
 
 func print_progress(p_path, p_progress):

--- a/addons/escoria-core/game/core-scripts/esc_room.gd
+++ b/addons/escoria-core/game/core-scripts/esc_room.gd
@@ -1,8 +1,8 @@
 @tool
 @icon("res://addons/escoria-core/design/esc_room.svg")
 ## A room in an Escoria based game.
-extends Node2D
 class_name ESCRoom
+extends Node2D
 
 
 ## Debugging displays for a room.

--- a/addons/escoria-core/game/core-scripts/esc_terrain.gd
+++ b/addons/escoria-core/game/core-scripts/esc_terrain.gd
@@ -1,12 +1,8 @@
 @tool
 @icon("res://addons/escoria-core/design/esc_terrain.svg")
 ## A walkable Terrain for Escoria rooms.
-extends Node2D
 class_name ESCTerrain
-
-
-## Logger class reference
-const EscLogger = preload("res://addons/escoria-core/tools/logging/esc_logger.gd")
+extends Node2D
 
 
 ## Visualize scales or lightmap for debugging purposes if the editor
@@ -16,6 +12,9 @@ enum DebugMode {
 	LIGHTMAP,
 }
 
+
+## Logger class reference
+const EscLogger = preload("res://addons/escoria-core/tools/logging/esc_logger.gd")
 
 
 @export_group("Scales")
@@ -169,9 +168,8 @@ func _check_multiple_enabled_navpolys(node: Node = null, is_exiting: bool = fals
 						"at the same time."
 					)
 				return
-			else:
-				navigation_enabled_found = true
-				current_active_navigation_instance = n
+			navigation_enabled_found = true
+			current_active_navigation_instance = n
 
 
 ## Return the Color of the lightmap pixel for the specified position.[br]

--- a/addons/escoria-core/game/core-scripts/esc_tooltip.gd
+++ b/addons/escoria-core/game/core-scripts/esc_tooltip.gd
@@ -1,7 +1,7 @@
 @tool
 ## Dynamically controlled tooltip
-extends RichTextLabel
 class_name ESCTooltip
+extends RichTextLabel
 
 
 ## Maximum width of the label
@@ -162,7 +162,6 @@ func update_tooltip_text():
 	"""
 	Overriden method. Should not be called directly.
 	"""
-	pass
 
 
 ## Update the tooltip size according to the text.[br]

--- a/addons/escoria-core/game/core-scripts/esc_walk_context.gd
+++ b/addons/escoria-core/game/core-scripts/esc_walk_context.gd
@@ -1,7 +1,7 @@
 ## The walk context describes the target of a walk command and if that command
 ## should be executed fast.
-extends RefCounted
 class_name ESCWalkContext
+extends RefCounted
 
 
 ## Target object that the walk command tries to reach.

--- a/addons/escoria-core/game/core-scripts/migrations/esc_migration.gd
+++ b/addons/escoria-core/game/core-scripts/migrations/esc_migration.gd
@@ -1,5 +1,5 @@
-extends RefCounted
 class_name ESCMigration
+extends RefCounted
 ## Base class for all migration version scripts. Extending scripts should be
 ## named like the version they migrate the savegame to. (e.g. 1.0.0.gd, 1.0.1.gd)
 

--- a/addons/escoria-core/game/core-scripts/migrations/esc_migration_manager.gd
+++ b/addons/escoria-core/game/core-scripts/migrations/esc_migration_manager.gd
@@ -1,7 +1,7 @@
 ## Class that handles migrations between different game or escoria versions
 ## @MANAGER
-extends RefCounted
 class_name ESCMigrationManager
+extends RefCounted
 
 
 ## Regular expression that matches a simple semver version string
@@ -160,18 +160,22 @@ func _version_between(version: String, from: String, to: String) -> bool:
 	if from_info.get_string("major") < version_info.get_string("major") and \
 			version_info.get_string("major") < to_info.get_string("major"):
 		return true
-	elif from_info.get_string("major") == version_info.get_string("major") and \
+
+	if from_info.get_string("major") == version_info.get_string("major") and \
 			from_info.get_string("minor") < version_info.get_string("minor"):
 		return true
-	elif from_info.get_string("major") == version_info.get_string("major") and \
+
+	if from_info.get_string("major") == version_info.get_string("major") and \
 			from_info.get_string("minor") == \
 				version_info.get_string("minor") and \
 			from_info.get_string("patch") < version_info.get_string("patch"):
 		return true
-	elif to_info.get_string("major") == version_info.get_string("major") and \
+
+	if to_info.get_string("major") == version_info.get_string("major") and \
 			to_info.get_string("minor") > version_info.get_string("minor"):
 		return true
-	elif to_info.get_string("major") == version_info.get_string("major") and \
+
+	if to_info.get_string("major") == version_info.get_string("major") and \
 			to_info.get_string("minor") == version_info.get_string("minor") and\
 			to_info.get_string("patch") > version_info.get_string("patch"):
 		return true
@@ -197,10 +201,12 @@ func _compare_version(version_a: String, version_b: String) -> bool:
 
 	if a_info.get_string("major") < b_info.get_string("major"):
 		return true
-	elif a_info.get_string("major") == b_info.get_string("major") and \
+
+	if a_info.get_string("major") == b_info.get_string("major") and \
 			a_info.get_string("minor") < b_info.get_string("minor"):
 		return true
-	elif a_info.get_string("major") == b_info.get_string("major") and \
+
+	if a_info.get_string("major") == b_info.get_string("major") and \
 			a_info.get_string("minor") == b_info.get_string("minor") and \
 			a_info.get_string("patch") < b_info.get_string("patch"):
 		return true

--- a/addons/escoria-core/game/core-scripts/resources/esc_animationname.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_animationname.gd
@@ -1,7 +1,7 @@
 @tool
 ## Class defining an animation to use for an angle.
-extends Resource
 class_name ESCAnimationName
+extends Resource
 
 ## Name of the animation
 @export var animation: String

--- a/addons/escoria-core/game/core-scripts/resources/esc_animationresource.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_animationresource.gd
@@ -1,8 +1,8 @@
 @tool
 ## Resource containing all defined animations and angles for character
 ## movement.[br]
-extends Resource
 class_name ESCAnimationResource
+extends Resource
 
 ## Array containing the different angles available for animations.[br]
 ## Each angle is defined by an array [start_angle, angle_size].

--- a/addons/escoria-core/game/core-scripts/resources/esc_directionangle.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_directionangle.gd
@@ -1,7 +1,7 @@
 @tool
 ## Class defining an angle, with a start angle (between 0 and 360) and a size.
-extends Resource
 class_name ESCDirectionAngle
+extends Resource
 
 ## Start angle of the directional angle.
 @export var angle_start: int

--- a/addons/escoria-core/game/core-scripts/resources/esc_resource_descriptor.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_resource_descriptor.gd
@@ -1,6 +1,6 @@
 ## Describes a resource for use in the resource cache.
-extends Resource
 class_name ESCResourceDescriptor
+extends Resource
 
 ## The resource being described.
 var res

--- a/addons/escoria-core/game/core-scripts/save_data/esc_savegame.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_savegame.gd
@@ -1,6 +1,6 @@
 ## Resource used for holding savegames data.
-extends Resource
 class_name ESCSaveGame
+extends Resource
 
 ## Access key for the main data last_scene_global_id.
 const MAIN_LAST_SCENE_GLOBAL_ID_KEY = "last_scene_global_id"

--- a/addons/escoria-core/game/core-scripts/save_data/esc_savesettings.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_savesettings.gd
@@ -1,8 +1,8 @@
 ## Resource holding game settings. Note that we call directly to ProjectSettings
 ## for instance variable initialization since this class is instantiated from
 ## escoria.gd.
-extends Resource
 class_name ESCSaveSettings
+extends Resource
 
 ## Version of ESCORIA Framework.
 @export var escoria_version: String

--- a/addons/escoria-core/game/core-scripts/utils/esc_utils.gd
+++ b/addons/escoria-core/game/core-scripts/utils/esc_utils.gd
@@ -1,6 +1,6 @@
 ## A set of common utilities.
-extends RefCounted
 class_name ESCUtils
+extends RefCounted
 
 ## Convert radians to degrees.[br]
 ## [br]
@@ -36,8 +36,7 @@ static func get_deg_from_rad(rad_angle: float):
 static func get_re_group(re_match: RegExMatch, group: String) -> String:
 	if group in re_match.names:
 		return re_match.strings[re_match.names[group]]
-	else:
-		return ""
+	return ""
 
 ## Return a string value in the correct inferred type.[br]
 ## [br]
@@ -61,16 +60,19 @@ static func get_typed_value(value: String, type_hint = []):
 
 	if regex_float.search(value):
 		return float(value)
-	elif regex_int.search(value):
+
+	if regex_int.search(value):
 		return int(value)
-	elif regex_bool.search(value.to_lower()):
+
+	if regex_bool.search(value.to_lower()):
 		return true if value.to_lower() == "true" else false
-	elif (typeof(type_hint) != TYPE_ARRAY and type_hint == TYPE_ARRAY) or \
+
+	if (typeof(type_hint) != TYPE_ARRAY and type_hint == TYPE_ARRAY) or \
 			(typeof(type_hint) == TYPE_ARRAY and TYPE_ARRAY in type_hint) \
 			and "," in value:
 		return value.split(",")
-	else:
-		return str(value)
+
+	return str(value)
 
 ## Sanitize use of whitespaces in a string. Removes double whitespaces and converts tabs into space.[br]
 ## [br]

--- a/addons/escoria-core/game/esc_project_settings_manager.gd
+++ b/addons/escoria-core/game/esc_project_settings_manager.gd
@@ -1,7 +1,7 @@
 ## Registers and allows access to Escoria-specific project settings.
 ## @MANAGER
-extends Resource
 class_name ESCProjectSettingsManager
+extends Resource
 
 ## Root for Escoria-specific project settings.
 const _ESCORIA_SETTINGS_ROOT = "escoria"

--- a/addons/escoria-core/game/main_scene.gd
+++ b/addons/escoria-core/game/main_scene.gd
@@ -1,8 +1,8 @@
 ## Main_scene is the entry point for Godot Engine.
 ##
 ## This scene sets up the main scene to load.
-extends Node
 class_name ESCMain
+extends Node
 
 ## Reference to the Escoria node instance.
 var escoria_node: Escoria

--- a/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
+++ b/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
@@ -1,6 +1,6 @@
 ## Camera handling for Escoria scenes.
-extends Camera2D
 class_name ESCCamera
+extends Camera2D
 
 ## Reference to the tween node for animating camera movements.
 var _tween: Tween3:

--- a/addons/escoria-core/game/scenes/camera_player/esc_camera_limits.gd
+++ b/addons/escoria-core/game/scenes/camera_player/esc_camera_limits.gd
@@ -1,6 +1,6 @@
 ## Describes a bounding box that limits the camera movement in the scene.
-extends RefCounted
 class_name ESCCameraLimits
+extends RefCounted
 
 ## The left side of the bounding box.
 var limit_left: int = -10000

--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_manager.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_manager.gd
@@ -1,7 +1,7 @@
 ## A base class for dialog plugins to work with Escoria
 ## @MANAGER
-extends Control
 class_name ESCDialogManager
+extends Control
 
 ## Emitted when the say function has completed showing the text[br]
 ## [br]
@@ -40,7 +40,7 @@ signal option_chosen(option)
 ## #### Returns[br]
 ## [br]
 ## Returns whether the type is supported or not. (`bool`)
-func has_type(type: String) -> bool:
+func has_type(_type: String) -> bool:
 	return false
 
 ## Checks whether a specific chooser type is supported by the dialog plugin.[br]
@@ -54,7 +54,7 @@ func has_type(type: String) -> bool:
 ## #### Returns[br]
 ## [br]
 ## Returns whether the type is supported or not. (`bool`)
-func has_chooser_type(type: String) -> bool:
+func has_chooser_type(_type: String) -> bool:
 	return false
 
 ## Outputs a text said by the item specified by the global id and emits `say_finished` after finishing displaying the text.[br]
@@ -72,7 +72,7 @@ func has_chooser_type(type: String) -> bool:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func say(dialog_player: Node, global_id: String, text: String, type: String, key: String):
+func say(_dialog_player: Node, _global_id: String, _text: String, _type: String, _key: String):
 	pass
 
 ## Instructs the dialog manager to preserve the next dialog box used by a `say` command until a call to `disable_preserve_dialog_box` is made. This method should be idempotent, i.e. if called after the first time and prior to `disable_preserve_dialog_box` being called, the result should be the same.[br]
@@ -112,7 +112,7 @@ func disable_preserve_dialog_box() -> void:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func choose(dialog_player: Node, dialog: ESCDialog, type: String):
+func choose(_dialog_player: Node, _dialog: ESCDialog, _type: String):
 	pass
 
 ## Triggers running the dialogue faster.[br]

--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_options_chooser.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_options_chooser.gd
@@ -1,6 +1,6 @@
 ## Base class for all dialog options implementations
-extends Control
 class_name ESCDialogOptionsChooser
+extends Control
 
 ## Emitted when an option is chosen.[br]
 ## [br]

--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
@@ -1,6 +1,6 @@
 ## Escoria dialog player
-extends Control
 class_name ESCDialogPlayer
+extends Control
 
 ## Emitted when an answer is chosen.[br]
 ## [br]
@@ -158,9 +158,9 @@ func _determine_say_dialog_manager(type: String) -> void:
 		ESCProjectSettingsManager.DIALOG_MANAGERS
 	):
 		if ResourceLoader.exists(_manager_class):
-			var _manager: ESCDialogManager = load(_manager_class).new()
-			if _manager.has_type(type):
-				dialog_manager = _manager
+			var manager: ESCDialogManager = load(_manager_class).new()
+			if manager.has_type(type):
+				dialog_manager = manager
 			else:
 				dialog_manager = null
 
@@ -191,9 +191,9 @@ func _determine_choose_dialog_manager(type: String) -> void:
 		ESCProjectSettingsManager.DIALOG_MANAGERS
 	):
 		if ResourceLoader.exists(_manager_class):
-			var _manager: ESCDialogManager = load(_manager_class).new()
-			if _manager.has_chooser_type(type):
-				dialog_manager = _manager
+			var manager: ESCDialogManager = load(_manager_class).new()
+			if manager.has_chooser_type(type):
+				dialog_manager = manager
 			else:
 				dialog_manager = null
 
@@ -248,7 +248,8 @@ func _determine_dialog_manager(dialog_type: String, dialog_manager_type: String)
 	if dialog_type == DIALOG_TYPE_SAY:
 		_determine_say_dialog_manager(dialog_manager_type)
 		return _say_dialog_manager
-	elif dialog_type == DIALOG_TYPE_CHOOSE:
+
+	if dialog_type == DIALOG_TYPE_CHOOSE:
 		_determine_choose_dialog_manager(dialog_manager_type)
 		return _choose_dialog_manager
 

--- a/addons/escoria-core/game/scenes/inventory/inventory_ui.gd
+++ b/addons/escoria-core/game/scenes/inventory/inventory_ui.gd
@@ -1,6 +1,6 @@
 ## Manages the inventory on the GUI connected to the inventory_ui_container variable.
-extends Control
 class_name ESCInventory
+extends Control
 
 ## The actual container node to add items as children of. Should be a Container.
 @export var inventory_ui_container: NodePath
@@ -167,7 +167,7 @@ func remove_item_by_id(item_id: String) -> void:
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func _on_escoria_global_changed(global: String, old_value, new_value) -> void:
+func _on_escoria_global_changed(global: String, _old_value, new_value) -> void:
 	if !global.begins_with("i/"):
 		return
 	var item = global.rsplit("i/", false)

--- a/addons/escoria-core/game/scenes/sound/esc_ambient_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_ambient_player.gd
@@ -1,6 +1,6 @@
 ## Background ambient sound player
-extends Control
 class_name ESCAmbientPlayer
+extends Control
 
 ## Global id of the background ambient sound player.
 @export var global_id: String = "_ambient"

--- a/addons/escoria-core/game/scenes/sound/esc_music_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_music_player.gd
@@ -1,6 +1,6 @@
 ## Background music player
-extends Control
 class_name ESCMusicPlayer
+extends Control
 
 ## Global id of the background music player.
 @export var global_id: String = "_music"

--- a/addons/escoria-core/game/scenes/sound/esc_sound_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_sound_player.gd
@@ -1,6 +1,6 @@
 ## Background sound player
-extends Control
 class_name ESCSoundPlayer
+extends Control
 
 ## Global id of the sfx sound player.
 @export var global_id: String = "_sound"

--- a/addons/escoria-core/game/scenes/sound/esc_speech_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_speech_player.gd
@@ -1,6 +1,6 @@
 ## Speech player
-extends Control
 class_name ESCSpeechPlayer
+extends Control
 
 ## Global id of the speech player.
 @export var global_id: String = "_speech"
@@ -21,7 +21,7 @@ class_name ESCSpeechPlayer
 ## #### Returns[br]
 ## [br]
 ## Returns nothing.
-func set_state(p_state: String, from_seconds: float = 0.0, p_force: bool = false) -> void:
+func set_state(p_state: String, from_seconds: float = 0.0, _p_force: bool = false) -> void:
 	# If speech is disabled, return
 	if not ESCProjectSettingsManager.get_setting(
 		ESCProjectSettingsManager.SPEECH_ENABLED

--- a/addons/escoria-core/game/scenes/transitions/esc_transition_player.gd
+++ b/addons/escoria-core/game/scenes/transitions/esc_transition_player.gd
@@ -1,6 +1,6 @@
 ## A transition player for scene changes
-extends ColorRect
 class_name ESCTransitionPlayer
+extends ColorRect
 
 ## Emitted when the transition was played[br]
 ## [br]
@@ -13,7 +13,7 @@ class_name ESCTransitionPlayer
 signal transition_done(transition_id)
 
 ## The valid transition modes
-enum TRANSITION_MODE {
+enum TransitionMode {
 	IN,
 	OUT
 }
@@ -68,7 +68,7 @@ func _ready() -> void:
 ## Returns the transition id. (`int`)
 func transition(
 	transition_name: String = "",
-	mode: int = TRANSITION_MODE.IN,
+	mode: int = TransitionMode.IN,
 	duration: float = 1.0
 ) -> int:
 
@@ -105,7 +105,7 @@ func transition(
 	var start = 0.0
 	var end = 1.0
 
-	if mode == TRANSITION_MODE.OUT:
+	if mode == TransitionMode.OUT:
 		start = 1.0
 		end = 0.0
 

--- a/addons/escoria-core/game/tween3.gd
+++ b/addons/escoria-core/game/tween3.gd
@@ -103,7 +103,16 @@ func _init(tween_parent: Node):
 ## [br]
 ## Returns nothing.
 func _create_tween():
-	_tween = _tween_parent.get_tree().create_tween()
+	var tree = _tween_parent.get_tree()
+	if tree == null:
+		push_error("Tween3: Parent node is not in the scene tree. Cannot create tween.")
+		return
+
+	_tween = tree.create_tween()
+	if _tween == null:
+		push_error("Tween3: Failed to create tween.")
+		return
+
 	_tween.pause()  # prevent autoplay
 
 	_tween.finished.connect(_on_finished)

--- a/addons/escoria-core/game/tween3.gd
+++ b/addons/escoria-core/game/tween3.gd
@@ -105,12 +105,18 @@ func _init(tween_parent: Node):
 func _create_tween():
 	var tree = _tween_parent.get_tree()
 	if tree == null:
-		push_error("Tween3: Parent node is not in the scene tree. Cannot create tween.")
+		escoria.logger.error(
+			self,
+			"Tween3: Parent node is not in the scene tree. Cannot create tween."
+		)
 		return
 
 	_tween = tree.create_tween()
 	if _tween == null:
-		push_error("Tween3: Failed to create tween.")
+		escoria.logger.error(
+			self,
+			"Tween3: Failed to create tween."
+		)
 		return
 
 	_tween.pause()  # prevent autoplay

--- a/addons/escoria-core/game/tween3.gd
+++ b/addons/escoria-core/game/tween3.gd
@@ -1,7 +1,27 @@
 ## In Godot 4, tweens cannot be resumed. But if you re-create them,[br]
 ## the bindings are lost. So this class wraps a tween and offers a reset function.
-extends RefCounted
 class_name Tween3
+extends RefCounted
+
+
+## Emitted when the tween finishes.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+signal finished()
+
+
+## The parent node for the tween.
+var _tween_parent: Node
+
+## The Tween instance being managed.
+var _tween: Tween
+
+## The duration of the tween.
+var _duration: float
+
 
 ## Interpolates a property on an object using a tween.[br]
 ## [br]
@@ -43,23 +63,6 @@ static func tween_interpolate_property(
 
 	return true
 
-
-## The parent node for the tween.
-var _tween_parent: Node
-
-## The Tween instance being managed.
-var _tween: Tween
-
-## The duration of the tween.
-var _duration: float
-
-## Emitted when the tween finishes.[br]
-## [br]
-## #### Parameters[br]
-## [br]
-## None.
-## [br]
-signal finished()
 
 ## Called when the tween finishes.[br]
 ## [br]


### PR DESCRIPTION
Fixed linter issues for the `addons/escoria-core/game/` folder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced tween management (Tween3) with playback controls and a `finished` signal, plus duration tracking and safe reset/rebuild behavior.
* **Refactor**
  * Standardized script declaration formatting and simplified internal control flow/unused-parameter handling across core game commands, dialogs, animations, and transitions.
* **Editor / Debug**
  * Updated the editor debug display option’s enum naming while keeping the available display modes the same.
* **Transitions**
  * Normalized the transition mode enum name for consistent transition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->