### PR TITLE
fix: simple-mouse: add missing method to make Pause button work

### DIFF
--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -499,3 +499,7 @@ func _on_input_mode_changed(new_mode):
 	):
 		return
 	$mouse_layer/verbs_menu.set_by_name(escoria.action_manager.current_action)
+
+
+func _on_MenuButton_pressed() -> void:
+	pause_game()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the verbs menu so it stays synchronized with the currently selected action.
- **New Features**
  - Added functionality for the UI Menu button to pause the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->