### PR TITLE
feat: Save camera limits into savegames

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -205,6 +205,7 @@ func get_save_data() -> Dictionary:
 
 	if self.global_id == "_camera":
 		save_data["target"] = self.node.get("_follow_target").global_id
+		save_data["limit_id"] = escoria.main.last_current_scene_camera_limit_id
 
 	return save_data
 

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -205,7 +205,9 @@ func get_save_data() -> Dictionary:
 
 	if self.global_id == "_camera":
 		save_data["target"] = self.node.get("_follow_target").global_id
-		save_data["limit_id"] = escoria.main.last_current_scene_camera_limit_id
+		var camera_limit_id = escoria.main.get_camera_limit_id_for_room(escoria.main.current_scene)
+		if camera_limit_id != null:
+			save_data["limit_id"] = camera_limit_id
 
 	return save_data
 

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -483,7 +483,7 @@ func _load_room_objects(room_id: String, objects_dictionary: Dictionary):
 	# Then load camera
 	if camera_loaded_data != null:
 		_load_object(escoria.object_manager.CAMERA, camera_loaded_data, room_id)
-	
+
 	escoria.logger.info(self, "Finished loading room '%s'" % room_id)
 
 ## Load one object saved in a savegame data.[br]
@@ -503,7 +503,13 @@ func _load_object(object_id: String, object_dictionary: Dictionary, _room_id: St
 	escoria.logger.info(self, "Loading object '%s'" % object_id)
 
 	if object_id == ESCObjectManager.CAMERA:
-		_camera_set_limits.run([object_dictionary["limit_id"]])
+		if object_dictionary.has("limit_id"):
+			escoria.main.restore_camera_limit_for_room_global_id(
+				_room_id,
+				object_dictionary["limit_id"]
+			)
+		else:
+			escoria.main.clear_camera_limit_id_for_room_global_id(_room_id)
 		_camera_set_target.run([0, object_dictionary["target"]])
 	else:
 		# Active

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -48,6 +48,7 @@ var _add_inventory: InventoryAddCommand
 var _transition: TransitionCommand
 var _hide_menu: HideMenuCommand
 var _camera_set_target: CameraSetTargetCommand
+var _camera_set_limits: CameraSetLimitsCommand
 var _change_scene: ChangeSceneCommand
 var _enable_terrain: EnableTerrainCommand
 var _set_active: SetActiveCommand
@@ -81,6 +82,7 @@ func _init():
 	_transition = TransitionCommand.new()
 	_hide_menu = HideMenuCommand.new()
 	_camera_set_target = CameraSetTargetCommand.new()
+	_camera_set_limits = CameraSetLimitsCommand.new()
 	_change_scene = ChangeSceneCommand.new()
 	_enable_terrain = EnableTerrainCommand.new()
 	_set_active = SetActiveCommand.new()
@@ -472,9 +474,16 @@ func _load_savegame_objects(savegame_objects: Dictionary):
 func _load_room_objects(room_id: String, objects_dictionary: Dictionary):
 	escoria.logger.info(self, "Loading room '%s'" % room_id)
 
+	var camera_loaded_data = null
+	if objects_dictionary.has(escoria.object_manager.CAMERA):
+		camera_loaded_data = objects_dictionary[escoria.object_manager.CAMERA]
+		objects_dictionary.erase(escoria.object_manager.CAMERA)
 	for object_id in objects_dictionary:
 		_load_object(object_id, objects_dictionary[object_id], room_id)
-
+	# Then load camera
+	if camera_loaded_data != null:
+		_load_object(escoria.object_manager.CAMERA, camera_loaded_data, room_id)
+	
 	escoria.logger.info(self, "Finished loading room '%s'" % room_id)
 
 ## Load one object saved in a savegame data.[br]
@@ -494,6 +503,7 @@ func _load_object(object_id: String, object_dictionary: Dictionary, _room_id: St
 	escoria.logger.info(self, "Loading object '%s'" % object_id)
 
 	if object_id == ESCObjectManager.CAMERA:
+		_camera_set_limits.run([object_dictionary["limit_id"]])
 		_camera_set_target.run([0, object_dictionary["target"]])
 	else:
 		# Active

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -25,6 +25,9 @@ var previous_scene: Node
 ## The Escoria context currently in wait state
 var wait_level
 
+## Last used camera limit id for current scene
+var last_current_scene_camera_limit_id: int
+
 ## Reference to the scene transition node
 @onready var scene_transition: ESCTransitionPlayer
 
@@ -203,6 +206,7 @@ func set_camera_limits(camera_limit_id: int = 0, scene: Node = current_scene) ->
 				last_available_camera_limit
 			]
 		)
+	last_current_scene_camera_limit_id = camera_limit_id
 	var scene_camera_limits = scene.camera_limits[camera_limit_id]
 	if scene_camera_limits.size.x == 0 and scene_camera_limits.size.y == 0:
 		var area = Rect2()

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -25,8 +25,8 @@ var previous_scene: Node
 ## The Escoria context currently in wait state
 var wait_level
 
-## Last used camera limit id for current scene
-var last_current_scene_camera_limit_id: int
+## Last used camera limit id by room global id
+var camera_limit_id_by_room_global_id: Dictionary = {}
 
 ## Reference to the scene transition node
 @onready var scene_transition: ESCTransitionPlayer
@@ -183,6 +183,98 @@ func _on_wait_finished() -> void:
 	escoria.esc_level_runner.finished(wait_level)
 
 
+## Returns true iff the specified camera limit id can be applied to the scene.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## |camera_limit_id|`int`|The camera limit id to check.|yes|[br]
+## |scene|`Node`|The scene to check against.|yes|[br]
+## [br]
+## #### Returns[br]
+## [br]
+## Returns `true` if the specified camera limit id can be applied to the scene.
+func _is_valid_camera_limit_id_for_room(camera_limit_id: int, scene: Node) -> bool:
+	if scene == null or not is_instance_valid(scene):
+		return false
+	if not (scene is ESCRoom):
+		return false
+
+	var last_available_camera_limit = scene.camera_limits.size() - 1
+	return camera_limit_id >= 0 and camera_limit_id <= last_available_camera_limit
+
+
+## Clears stored camera limit id for the specified scene global id.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## |scene_global_id|`String`|The global id of the scene.|yes|[br]
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func clear_camera_limit_id_for_room(scene_global_id: String) -> void:
+	if scene_global_id == "":
+		return
+	camera_limit_id_by_room_global_id.erase(scene_global_id)
+
+
+## Returns the stored camera limit id for the scene if it is valid.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## |room|`Node`|The room to get the camera limit id for.|yes|[br]
+## [br]
+## #### Returns[br]
+## [br]
+## Returns the stored camera limit id for the scene if it is valid.
+func get_camera_limit_id_for_room(room: Node) -> Variant:
+	if room == null or not is_instance_valid(room):
+		return null
+	if not (room is ESCRoom):
+		return null
+	if not camera_limit_id_by_room_global_id.has(room.global_id):
+		return null
+
+	var stored_camera_limit_id = camera_limit_id_by_room_global_id[room.global_id]
+	if typeof(stored_camera_limit_id) != TYPE_INT:
+		camera_limit_id_by_room_global_id.erase(room.global_id)
+		return null
+	if not _is_valid_camera_limit_id_for_room(stored_camera_limit_id, room):
+		camera_limit_id_by_room_global_id.erase(room.global_id)
+		return null
+
+	return stored_camera_limit_id
+
+
+## Restores camera limits for a scene global id iff the id belongs to that scene.
+## [br]
+## #### Parameters[br]
+## [br]
+## |room_global_id|`String`|The room to get the camera limit id for.|yes|[br]
+## |camera_limit_id|`int`|The camera limit id to restore for the room.|yes|[br]
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func restore_camera_limit_for_room_global_id(room_global_id: String, camera_limit_id: Variant) -> void:
+	if room_global_id == "":
+		return
+	if current_scene == null or not (current_scene is ESCRoom):
+		clear_camera_limit_id_for_room(room_global_id)
+		return
+	if current_scene.global_id != room_global_id:
+		clear_camera_limit_id_for_room(room_global_id)
+		return
+	if typeof(camera_limit_id) != TYPE_INT:
+		clear_camera_limit_id_for_room(room_global_id)
+		return
+	if not _is_valid_camera_limit_id_for_room(camera_limit_id, current_scene):
+		clear_camera_limit_id_for_room(room_global_id)
+		return
+
+	set_camera_limits(camera_limit_id, current_scene)
+
+
 ## Set the camera limits[br]
 ## [br]
 ## #### Parameters[br]
@@ -197,8 +289,13 @@ func _on_wait_finished() -> void:
 ## Returns nothing.
 func set_camera_limits(camera_limit_id: int = 0, scene: Node = current_scene) -> void:
 	var limits = {}
+	if scene == null or not is_instance_valid(scene):
+		return
+	if not (scene is ESCRoom):
+		return
+
 	var last_available_camera_limit = scene.camera_limits.size() - 1
-	if camera_limit_id > last_available_camera_limit:
+	if camera_limit_id < 0 or camera_limit_id > last_available_camera_limit:
 		escoria.logger.error(
 			self,
 			"Camera3D limit %d requested. Last available camera limit is %d." % [
@@ -206,7 +303,8 @@ func set_camera_limits(camera_limit_id: int = 0, scene: Node = current_scene) ->
 				last_available_camera_limit
 			]
 		)
-	last_current_scene_camera_limit_id = camera_limit_id
+		camera_limit_id_by_room_global_id.erase(scene.global_id)
+		return
 	var scene_camera_limits = scene.camera_limits[camera_limit_id]
 	if scene_camera_limits.size.x == 0 and scene_camera_limits.size.y == 0:
 		var area = Rect2()
@@ -252,6 +350,8 @@ func set_camera_limits(camera_limit_id: int = 0, scene: Node = current_scene) ->
 	escoria.object_manager.get_object(
 		escoria.object_manager.CAMERA
 	).node.set_limits(limits)
+	camera_limit_id_by_room_global_id[scene.global_id] = camera_limit_id
+
 
 
 ## Save the game state to the provided savegame resource.[br]

--- a/game/rooms/room07/esc/lift_door_floor_1.esc
+++ b/game/rooms/room07/esc/lift_door_floor_1.esc
@@ -8,6 +8,7 @@
 		teleport_pos($player, 5000, 5000)
 		set_angle($player, 180)
 		camera_push($r7_lift_door_floor_2, 3)
+		set_state($r7_lift, "lift_floor_1_to_2_with_player")
 		anim_block($r7_lift, "lift_floor_1_to_2_with_player")
 		teleport($player, "r7_lift_door_floor_2")
 		say($r7_lift_door_floor_2, "Ding!")

--- a/game/rooms/room07/esc/lift_door_floor_2.esc
+++ b/game/rooms/room07/esc/lift_door_floor_2.esc
@@ -8,6 +8,7 @@
 		teleport_pos($player, 5000, 5000)
 		set_angle($player, 180)
 		camera_push($r7_lift_door_floor_1, 3)
+		set_state($r7_lift, "lift_floor_2_to_1_with_player")
 		anim_block($r7_lift, "lift_floor_2_to_1_with_player")
 		teleport($player, "r7_lift_door_floor_1")
 		say($r7_lift_door_floor_1, "Ding!")


### PR DESCRIPTION
Merge after #1253 

+ fix lift states in room 07 so they're saved rightfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Camera limits are now preserved and restored separately for each room when saving and loading games.
  * Invalid camera-limit selections are automatically rejected or cleared.

* **Bug Fixes**
  * Camera settings now load in the correct order during room restoration.
  * Lift transitions correctly update their state while moving between floors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->