### PR TITLE
fix: Resume sounds after transition in on savegame load

### DIFF
--- a/addons/escoria-core/editor/migration_4_6_4_7/acceptdialog_migrate_4_6_4_7.gd
+++ b/addons/escoria-core/editor/migration_4_6_4_7/acceptdialog_migrate_4_6_4_7.gd
@@ -20,38 +20,38 @@ func _ready() -> void:
 	match action:
 		Migrator4647.MigrationAction.UPGRADE_4_7:
 			title = "Auto-upgrade Escoria-core scripts for Godot Engine 4.7.x"
-			label.text = """The version of Godot Engine you appear to be running is newer
-					than the one this version of Escoria relies on (4.6.x) or this is the first time
-					you run this version of Escoria.\n
-					Godot Engine 4.6 and 4.7 APIs have some differences in methods that Escoria makes use of.
-					Escoria can now automatically revert its impacted core scripts to makes them compatible
-					with Godot Engine 4.7.\n
-					Here is the list of the impacted files:
-					- res://addons/escoria-core/game/core-scripts/esc_item.gd\n
-					⚠️IMPORTANT⚠️: the editor will restart after this action is done.\n
-					If you wish to let Escoria proceed, choose 'OK'.
-					If you wish to upgrade to a newer version of Godot, choose 'Cancel'.
-					If you have edited these files for your own needs, you'll need to manually fix them:
-					choose 'Cancel' (see README; existing files will be backuped anyway).
-					"""
+			label.text = \
+"""The version of Godot Engine you appear to be running is newer
+than the one this version of Escoria relies on (4.6.x) or this is the first time
+you run this version of Escoria.\n
+Godot Engine 4.6 and 4.7 APIs have some differences in methods that Escoria makes use of.
+Escoria can now automatically revert its impacted core scripts to makes them compatible
+with Godot Engine 4.7.\n
+Here is the list of the impacted files:
+- res://addons/escoria-core/game/core-scripts/esc_item.gd\n
+⚠️IMPORTANT⚠️: the editor will restart after this action is done.\n
+If you wish to let Escoria proceed, choose 'OK'.
+If you wish to upgrade to a newer version of Godot, choose 'Cancel'.
+If you have edited these files for your own needs, you'll need to manually fix them:
+choose 'Cancel' (see README; existing files will be backuped anyway)."""
 			required_migration = true
 		Migrator4647.MigrationAction.DOWNGRADE_4_6:
 			title = "Auto-downgrade Escoria-core scripts for Godot Engine 4.6.x"
-			label.text = """The version of Godot Engine you appear to be running is older
-					than the one this version of Escoria relies on (4.7.x) or this is the first time
-					you run this version of Escoria.\n
-					Godot Engine 4.6 and 4.7 APIs have some differences in methods that Escoria makes use of.
-					Escoria can now automatically revert its impacted core scripts to makes them compatible
-					with Godot Engine 4.6.\n
-					Here is the list of the impacted files:
-					- res://addons/escoria-core/game/core-scripts/esc_item.gd\n
-					⚠️IMPORTANT⚠️: the editor will restart after this action is done.\n
-					If you wish to let Escoria proceed, choose 'OK' (a backup of the existing file will be created).
-					If you wish to upgrade to a newer version of Godot, choose 'Cancel' (nothing will be done,
-					but this tool will happen next time you open the editor).
-					If you have edited these files for your own needs, you'll need to manually fix them:
-					choose 'Cancel' (see README; existing files will be backuped anyway).
-					"""
+			label.text = \
+"""The version of Godot Engine you appear to be running is older
+than the one this version of Escoria relies on (4.7.x) or this is the first time
+you run this version of Escoria.\n
+Godot Engine 4.6 and 4.7 APIs have some differences in methods that Escoria makes use of.
+Escoria can now automatically revert its impacted core scripts to makes them compatible
+with Godot Engine 4.6.\n
+Here is the list of the impacted files:
+- res://addons/escoria-core/game/core-scripts/esc_item.gd\n
+⚠️IMPORTANT⚠️: the editor will restart after this action is done.\n
+If you wish to let Escoria proceed, choose 'OK' (a backup of the existing file will be created).
+If you wish to upgrade to a newer version of Godot, choose 'Cancel' (nothing will be done,
+but this tool will happen next time you open the editor).
+If you have edited these files for your own needs, you'll need to manually fix them:
+choose 'Cancel' (see README; existing files will be backuped anyway)."""
 			required_migration = true
 
 		_:

--- a/addons/escoria-core/editor/migration_4_6_4_7/acceptdialog_migrate_4_6_4_7.tscn
+++ b/addons/escoria-core/editor/migration_4_6_4_7/acceptdialog_migrate_4_6_4_7.tscn
@@ -32,8 +32,8 @@ text = "The version of Godot Engine you appear to be running is older
 					If you wish to let Escoria proceed, choose 'OK'.
 					If you wish to upgrade to a newer version of Godot, choose 'Cancel'.
 					If you have edited these files for your own needs, you'll need to manually fix them:
-					choose 'Cancel' (see README; existing files will be backuped anyway).
-					"
+					choose 'Cancel' (see README; existing files will be backuped anyway)."
+autowrap_mode = 3
 
 [node name="mark_this_as_done" type="CheckButton" parent="FlowContainer" unique_id=99402283]
 layout_mode = 2

--- a/addons/escoria-core/game/core-scripts/esc/commands/play_snd.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/play_snd.gd
@@ -20,6 +20,19 @@ extends ESCBaseCommand
 var _snd_player: String
 
 
+## Constructor of this command.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func _init() -> void:
+	run_in_ready_allowed_during_savegame_loading = false
+
+
 ## The descriptor of the arguments of this command.[br]
 ## [br]
 ## #### Parameters[br]

--- a/addons/escoria-core/game/core-scripts/esc/commands/stop_snd.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/stop_snd.gd
@@ -19,6 +19,20 @@ var previous_snd_state: String
 ## The specified sound player
 var _snd_player: String
 
+
+## Constructor of this command.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func _init() -> void:
+	run_in_ready_allowed_during_savegame_loading = false
+
+
 ## The descriptor of the arguments of this command.[br]
 ## [br]
 ## #### Parameters[br]

--- a/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
@@ -217,7 +217,8 @@ func register_object(object: ESCObject, room: ESCRoom = null, force: bool = fals
 	# forcing the registration, since we don't know if this object will be
 	# overwritten ("forced") in the future and, if it is, if it's set to
 	# auto-unregister or not. In most cases, objects are set to auto unregister.
-	if object.node.tree_exited.is_connected(object.unregister_object_callback):
+	if not object.unregister_object_callback.is_null() and \
+			object.node.tree_exited.is_connected(object.unregister_object_callback):
 		object.node.tree_exited.disconnect(object.unregister_object_callback)
 
 	if force:

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
@@ -11,7 +11,7 @@ var filename: String = ""
 ## The line number from the file the relevant command is being called from.
 var line_number: int = 0
 
-## Whether the command is allowed to be ran in a room's :ready event during a 
+## Whether the command is allowed to be ran in a room's :ready event during a
 ## savegame loading. This is especially the case for sound control commands,
 ## for which the Save Manager resumes from the recorded position.[br]
 ## Set this to `false` in the `_init()` method of such commands when necessary.

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
@@ -11,6 +11,12 @@ var filename: String = ""
 ## The line number from the file the relevant command is being called from.
 var line_number: int = 0
 
+## Whether the command is allowed to be ran in a room's :ready event during a 
+## savegame loading. This is especially the case for sound control commands,
+## for which the Save Manager resumes from the recorded position.[br]
+## Set this to `false` in the `_init()` method of such commands when necessary.
+var run_in_ready_allowed_during_savegame_loading: bool = true
+
 
 ## A descriptor (contained in `ESCCommandArgumentDescriptor`) of the arguments of this command.[br]
 ## [br]

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
@@ -115,6 +115,7 @@ func run() -> int:
 				"Skipped command %s with parameters %s because it is not allowed to be ran from :ready event during savegame load."
 						% [self.name, prepared_arguments]
 			)
+			_running_command_impl = null
 			return ESCExecution.RC_WONT_QUEUE
 		escoria.logger.debug(
 			self,

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
@@ -107,6 +107,15 @@ func run() -> int:
 	)
 
 	if command_object.validate(prepared_arguments):
+		if escoria.save_manager.is_loading_game \
+				and escoria.event_manager.get_running_event(escoria.event_manager.CHANNEL_FRONT).get_event_name() == escoria.event_manager.EVENT_READY \
+				and not command_object.run_in_ready_allowed_during_savegame_loading:
+			escoria.logger.debug(
+				self,
+				"Skipped command %s with parameters %s because it is not allowed to be ran from :ready event during savegame load."
+						% [self.name, prepared_arguments]
+			)
+			return ESCExecution.RC_WONT_QUEUE
 		escoria.logger.debug(
 			self,
 			"Running command %s with parameters %s."

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -200,7 +200,8 @@ func get_save_data() -> Dictionary:
 
 	if self.global_id in ["_music", "_sound", "_ambient"] and self.node.get("state"):
 		save_data["state"] = self.node.get("state")
-		save_data["playback_position"] = self.node.get_playback_position()
+		if escoria.settings_manager.get_settings_dict()[ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION]:
+			save_data["playback_position"] = self.node.get_playback_position()
 
 	if self.global_id == "_camera":
 		save_data["target"] = self.node.get("_follow_target").global_id

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -670,8 +670,8 @@ func set_animations(p_animations: ESCAnimationResource) -> void:
 
 	animations = p_animations
 
-	if not animations.changed.is_connected(validate_animations):
-		animations.changed.connect(validate_animations)
+	if not animations.is_connected("changed", Callable(self, "_validate_animations")):
+		animations.connect("changed", Callable(self, "_validate_animations"))
 
 
 ## The animation player node[br]

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -670,8 +670,8 @@ func set_animations(p_animations: ESCAnimationResource) -> void:
 
 	animations = p_animations
 
-	if not animations.is_connected("changed", Callable(self, "_validate_animations")):
-		animations.connect("changed", Callable(self, "_validate_animations"))
+	if not animations.changed.is_connected(validate_animations):
+		animations.changed.connect(validate_animations)
 
 
 ## The animation player node[br]

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -297,6 +297,9 @@ func load_game(id: int):
 		)
 		return
 
+	# Stop all musics and sounds
+	escoria.main.stop_all_sounds()
+
 	# Disconnect all trigger areas in the current room so that they don't
 	# trigger after room is loaded (eg: when player was in a trigger area,
 	# trigger_out won't fire after loading the game)
@@ -389,7 +392,16 @@ func load_game(id: int):
 	escoria.current_state = escoria.GameState.LOADING
 
 	escoria.room_manager.change_scene_to_file(save_game.main.current_scene_filename, false)
+	
+	# Pop sound and music data from the savegame
+	var sound_music_saved_data: Dictionary = {}
+	for object_id in save_game.objects:
+		if object_id in ESCObjectManager.RESERVED_OBJECTS: 
+			sound_music_saved_data[object_id] = save_game.objects[object_id]
+	for object_id in sound_music_saved_data:
+		save_game.objects.erase(object_id)
 
+	# Load the object
 	_load_savegame_objects(save_game.objects)
 
 	escoria.globals_manager.clear()
@@ -397,7 +409,10 @@ func load_game(id: int):
 	_load_savegame_inventory(save_game.inventory)
 	_load_savegame_terrain_navpolys(save_game.terrain_navpolys)
 	_load_savegame_events(save_game.events)
-	_transition.run(["", "in", 1.0])
+	await _transition.run(["", "in", 1.0])
+
+	# Music and sound resume
+	_load_savegame_objects(sound_music_saved_data)
 
 	escoria.set_game_paused(false)
 
@@ -425,12 +440,19 @@ func load_game(id: int):
 func _load_savegame_objects(savegame_objects: Dictionary):
 	for object_id in savegame_objects:
 		var saved_object_data = savegame_objects[object_id]
-		if object_id in ESCObjectManager.RESERVED_OBJECTS: # Sound players only atm
+		if object_id in ESCObjectManager.RESERVED_OBJECTS: 
+			# Sound players only atm
+			# Sounds and music to be resumed after transition
 			if saved_object_data.has("state") \
 					and saved_object_data["state"] in ["off", "default"]:
 				_stop_snd.run([object_id])
 			else:
-				_play_snd.run([saved_object_data["state"], object_id, saved_object_data["playback_position"]])
+				var playback_position: float = 0.0
+				if ESCProjectSettingsManager.get_setting(
+							ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION
+						) and saved_object_data.has("playback_position"):
+					playback_position = saved_object_data["playback_position"]
+				_play_snd.run([saved_object_data["state"], object_id, playback_position])
 		else:
 			if object_id == escoria.main.current_scene.global_id:
 				_load_room_objects(object_id, saved_object_data)

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -392,11 +392,11 @@ func load_game(id: int):
 	escoria.current_state = escoria.GameState.LOADING
 
 	escoria.room_manager.change_scene_to_file(save_game.main.current_scene_filename, false)
-	
+
 	# Pop sound and music data from the savegame
 	var sound_music_saved_data: Dictionary = {}
 	for object_id in save_game.objects:
-		if object_id in ESCObjectManager.RESERVED_OBJECTS: 
+		if object_id in ESCObjectManager.RESERVED_OBJECTS:
 			sound_music_saved_data[object_id] = save_game.objects[object_id]
 	for object_id in sound_music_saved_data:
 		save_game.objects.erase(object_id)
@@ -440,7 +440,7 @@ func load_game(id: int):
 func _load_savegame_objects(savegame_objects: Dictionary):
 	for object_id in savegame_objects:
 		var saved_object_data = savegame_objects[object_id]
-		if object_id in ESCObjectManager.RESERVED_OBJECTS: 
+		if object_id in ESCObjectManager.RESERVED_OBJECTS:
 			# Sound players only atm
 			# Sounds and music to be resumed after transition
 			if saved_object_data.has("state") \

--- a/addons/escoria-core/game/esc_project_settings_manager.gd
+++ b/addons/escoria-core/game/esc_project_settings_manager.gd
@@ -47,6 +47,9 @@ const SETTINGS_PATH = _ESCORIA_SETTINGS_ROOT + "/" + _MAIN_ROOT + "/" + "setting
 const TEXT_LANG = _ESCORIA_SETTINGS_ROOT + "/" + _MAIN_ROOT + "/" + "text_lang"
 ## Path to the voice language setting.
 const VOICE_LANG = _ESCORIA_SETTINGS_ROOT + "/" + _MAIN_ROOT + "/" + "voice_lang"
+## Save sounds playback position in savegames. If this is false, playback will resume from beginning
+## after loading.
+const SAVE_SOUNDS_PLAYBACK_POSITION = _ESCORIA_SETTINGS_ROOT + "/" + _MAIN_ROOT + "/" + "save_sounds_playback_position"
 
 ## Debug-related Escoria project settings root.
 const _DEBUG_ROOT = "debug"

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -413,8 +413,8 @@ func show_current_scene() -> void:
 ## [br]
 ## Returns nothing.
 func stop_all_sounds() -> void:
-	var _stop_snd: StopSndCommand = StopSndCommand.new()
-	_stop_snd.run([ESCObjectManager.AMBIENT])
-	_stop_snd.run([ESCObjectManager.MUSIC])
-	_stop_snd.run([ESCObjectManager.SOUND])
-	_stop_snd.run([ESCObjectManager.SPEECH])
+	var stop_snd: StopSndCommand = StopSndCommand.new()
+	stop_snd.run([ESCObjectManager.AMBIENT])
+	stop_snd.run([ESCObjectManager.MUSIC])
+	stop_snd.run([ESCObjectManager.SOUND])
+	stop_snd.run([ESCObjectManager.SPEECH])

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -402,3 +402,19 @@ func show_ui() -> void:
 func show_current_scene() -> void:
 	if escoria.main.current_scene != null:
 		escoria.main.current_scene.show()
+
+## Stops all sound channels.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func stop_all_sounds() -> void:
+	var _stop_snd: StopSndCommand = StopSndCommand.new()
+	_stop_snd.run([ESCObjectManager.AMBIENT])
+	_stop_snd.run([ESCObjectManager.MUSIC])
+	_stop_snd.run([ESCObjectManager.SOUND])
+	_stop_snd.run([ESCObjectManager.SPEECH])

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -317,6 +317,14 @@ func _set_escoria_main_settings():
 		}
 	)
 
+	register_setting(
+		ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION,
+		true,
+		{
+			"type": TYPE_BOOL,
+		}
+	)
+
 
 ## Prepare the settings in the Escoria debug category[br]
 ## [br]


### PR DESCRIPTION
Merge after #1253 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to preserve sound playback positions across savegame loading.
  * Sounds are stopped and restored consistently when loading a save.
  * Added support for stopping all sound channels at once.

* **Bug Fixes**
  * Prevented ready-time sound commands from running during savegame loading.
  * Improved object re-registration safety.
  * Added automatic text wrapping to the migration dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->