### PR TITLE
fix: workaround pen and paper items being active after given filled sheet to worker

### DIFF
--- a/game/items/inventory/pen.esc
+++ b/game/items/inventory/pen.esc
@@ -20,5 +20,6 @@
 	say("player", "Name...")
 	say("player", "Address...")
 	inventory_add("r5_filled_sheet")
+	pen_and_paper_used = true
 	# Allow player interaction again
 	accept_input("ALL")

--- a/game/rooms/room05/esc/room05.esc
+++ b/game/rooms/room05/esc/room05.esc
@@ -9,6 +9,7 @@
 	global room5_visited = true
 	global r5_pipe_broken = true
 	global r5_dialog_advance = 0
+	global pen_and_paper_used = false
 
 	# Disable wrench item if present in the inventory
 	if $r5_wrench in inventory:
@@ -27,8 +28,8 @@
 	if "r5_empty_sheet" in inventory:
 		set_active("r5_empty_sheet", false)
 
-	# Disable both the pen and sheet if the completed form is present in the inventory
-	if "r5_filled_sheet" in inventory:
+	# Disable both the pen and sheet if the completed form is present in the inventory, or if the pen & paper were "used" to create the completed form
+	if "r5_filled_sheet" in inventory or pen_and_paper_used:
 		set_active("r5_pen", false)
 		set_active("r5_empty_sheet", false)
 

--- a/game/rooms/room06/esc/room06.esc
+++ b/game/rooms/room06/esc/room06.esc
@@ -19,6 +19,8 @@
 		teleport("player", "r6_r_exit")
 		# Set player look left
 		set_angle("player", 270)
+		if !r6_r_exit_locked:
+			set_active("worker", false)
 
 
 :ready

--- a/game/rooms/room06/esc/room06.esc
+++ b/game/rooms/room06/esc/room06.esc
@@ -19,8 +19,9 @@
 		teleport("player", "r6_r_exit")
 		# Set player look left
 		set_angle("player", 270)
-		if !r6_r_exit_locked:
-			set_active("worker", false)
+
+	if !r6_r_exit_locked:
+		set_active("worker", false)
 
 
 :ready


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the pen-and-paper interaction in Room 05 so the pen is marked as used when the sequence begins.
  - Ensured the pen and blank sheet remain unavailable after use, keeping inventory and room state consistent.
  - Updated Room 06 so the worker is disabled when the exit is unlocked, preventing the worker from appearing in an invalid room state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->