### PR TITLE
feat: save current player animation (costume)

### DIFF
--- a/.github/workflows/esc-item-sync.yml
+++ b/.github/workflows/esc-item-sync.yml
@@ -1,0 +1,90 @@
+name: "ESCItem pre-4.7 sync"
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+jobs:
+  esc-item-sync:
+    name: "Check ESCItem mirror files"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: "Detect ESCItem file changes"
+        id: changed_files
+        uses: step-security/changed-files@60967b822d3001fa82242f8d6b4ed46bc3600a68 # v47.0.1
+        with:
+          files: |
+            addons/escoria-core/game/core-scripts/esc_item.gd
+            addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd
+            addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd
+
+      - name: "Verify ESCItem mirrors stay in sync"
+        if: steps.changed_files.outputs.any_changed == 'true'
+        run: |
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import difflib
+          import pathlib
+          import sys
+
+          root = pathlib.Path.cwd()
+          files = {
+              "main": root / "addons/escoria-core/game/core-scripts/esc_item.gd",
+              "4.6": root / "addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd",
+              "4.7": root / "addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd",
+          }
+
+          def normalized_text(path: pathlib.Path, version: str) -> str:
+              text = path.read_text(encoding="utf-8")
+              lines = text.splitlines()
+
+              if version == "4.6" and lines[:1] == ["# 4.6"]:
+                  lines = lines[1:]
+
+              return "\n".join(lines)
+
+          normalized = {
+              name: normalized_text(path, name)
+              for name, path in files.items()
+          }
+
+          baseline = normalized["main"]
+          mismatches = []
+
+          for name in ("4.6", "4.7"):
+              if normalized[name] != baseline:
+                  mismatches.append(name)
+
+          if mismatches:
+              print("ESCItem mirror files are out of sync with the main file:")
+              print("- addons/escoria-core/game/core-scripts/esc_item.gd")
+              print("- addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd")
+              print("- addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd")
+              print()
+
+              for name in mismatches:
+                  other = normalized[name]
+                  diff = difflib.unified_diff(
+                      baseline.splitlines(),
+                      other.splitlines(),
+                      fromfile="esc_item.gd",
+                      tofile=f"esc_item.{name}.gd",
+                      lineterm="",
+                  )
+                  print(f"--- Diff vs {name} ---")
+                  print("\n".join(diff))
+                  print()
+
+              sys.exit(1)
+
+          print("ESCItem mirror files are synchronized.")
+          PY

--- a/.github/workflows/esc-item-sync.yml
+++ b/.github/workflows/esc-item-sync.yml
@@ -30,6 +30,68 @@ jobs:
             addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd
             addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd
 
+      - name: "Verify esc_item.gd equals esc_item.4.7.gd (normalized)"
+        if: steps.changed_files.outputs.any_changed == 'true'
+        run: |
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import difflib
+          import pathlib
+          import sys
+
+          root = pathlib.Path.cwd()
+          main_path = root / "addons/escoria-core/game/core-scripts/esc_item.gd"
+          v47_path = root / "addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd"
+
+          def strip_configuration_warnings_block(lines: list[str]) -> list[str]:
+              func_name = "func _get_configuration_warnings():"
+              try:
+                  func_index = next(i for i, line in enumerate(lines) if line.strip() == func_name)
+              except StopIteration:
+                  return lines
+
+              start = func_index
+              while start > 0:
+                  previous = lines[start - 1]
+                  if previous.startswith("##") or previous.strip() == "":
+                      start -= 1
+                      continue
+                  break
+
+              end = func_index + 1
+              while end < len(lines):
+                  current = lines[end]
+                  if current.startswith("\t") or current.startswith("    ") or current.strip() == "":
+                      end += 1
+                      continue
+                  break
+
+              return lines[:start] + lines[end:]
+
+          def normalized_text(path: pathlib.Path) -> str:
+              lines = path.read_text(encoding="utf-8").splitlines()
+              lines = strip_configuration_warnings_block(lines)
+              return "\n".join(lines)
+
+          main_text = normalized_text(main_path)
+          v47_text = normalized_text(v47_path)
+
+          if main_text != v47_text:
+              print("esc_item.gd and esc_item.4.7.gd differ (after normalization).")
+              diff = difflib.unified_diff(
+                  main_text.splitlines(),
+                  v47_text.splitlines(),
+                  fromfile="esc_item.gd",
+                  tofile="esc_item.4.7.gd",
+                  lineterm="",
+              )
+              print("\n".join(diff))
+              sys.exit(1)
+
+          print("esc_item.gd and esc_item.4.7.gd are synchronized (after normalization).")
+          PY
+
       - name: "Verify ESCItem mirrors stay in sync"
         if: steps.changed_files.outputs.any_changed == 'true'
         run: |
@@ -47,9 +109,36 @@ jobs:
               "4.7": root / "addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd",
           }
 
+          def strip_configuration_warnings_block(lines: list[str]) -> list[str]:
+              func_name = "func _get_configuration_warnings():"
+              try:
+                  func_index = next(i for i, line in enumerate(lines) if line.strip() == func_name)
+              except StopIteration:
+                  return lines
+
+              start = func_index
+              while start > 0:
+                  previous = lines[start - 1]
+                  if previous.startswith("##") or previous.strip() == "":
+                      start -= 1
+                      continue
+                  break
+
+              end = func_index + 1
+              while end < len(lines):
+                  current = lines[end]
+                  if current.startswith("\t") or current.startswith("    ") or current.strip() == "":
+                      end += 1
+                      continue
+                  break
+
+              return lines[:start] + lines[end:]
+
           def normalized_text(path: pathlib.Path, version: str) -> str:
               text = path.read_text(encoding="utf-8")
               lines = text.splitlines()
+
+              lines = strip_configuration_warnings_block(lines)
 
               if version == "4.6" and lines[:1] == ["# 4.6"]:
                   lines = lines[1:]

--- a/.github/workflows/esc-item-sync.yml
+++ b/.github/workflows/esc-item-sync.yml
@@ -10,12 +10,16 @@ jobs:
   esc-item-sync:
     name: "Check ESCItem mirror files"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: "Detect ESCItem file changes"
         id: changed_files

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_animations.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_animations.gd
@@ -57,7 +57,7 @@ func validate(arguments: Array):
 		)
 		return false
 
-	(escoria.object_manager.get_object(arguments[0]).node as ESCPlayer).validate_animations(load(arguments[1]))
+	(escoria.object_manager.get_object(arguments[0]).node as ESCItem).validate_animations(load(arguments[1]))
 
 	return true
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_animations.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_animations.gd
@@ -74,7 +74,7 @@ func validate(arguments: Array):
 ## [br]
 ## Returns the execution result code. (`int`)
 func run(command_params: Array) -> int:
-	(escoria.object_manager.get_object(command_params[0]).node as ESCPlayer)\
+	(escoria.object_manager.get_object(command_params[0]).node as ESCItem)\
 			.animations = load(command_params[1])
 	if not escoria.globals_manager.has(
 		escoria.room_manager.GLOBAL_ANIMATION_RESOURCES

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -193,9 +193,10 @@ func get_save_data() -> Dictionary:
 	if is_instance_valid(self.node):
 		if self.node is ESCItem:
 			if self.node.animations != null:
-				var a = (self.node as ESCItem).animations
 				save_data["animations_resource_path"] = (self.node as ESCItem).animations.resource_path
-				save_data["current_animation"] = (self.node as ESCItem).get_animation_player().get_current_animation()
+				var animation_player = (self.node as ESCItem).get_animation_player()
+				if is_instance_valid(animation_player):
+					save_data["current_animation"] = animation_player.get_current_animation()
 
 		if self.node.get("is_movable") and self.node.is_movable:
 			save_data["global_transform"] = self.node.global_transform

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -201,6 +201,7 @@ func get_save_data() -> Dictionary:
 			save_data["global_transform"] = self.node.global_transform
 			save_data["last_deg"] = wrapi(self.node._movable._get_angle() - 90 + 1, 0, 360)
 			save_data["last_dir"] = self.node._movable.last_dir
+			save_data["speed"] = self.node.speed
 		if self.node.has_method("get_custom_data"):
 			save_data["custom_data"] = self.node.get_custom_data()
 

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -191,6 +191,12 @@ func get_save_data() -> Dictionary:
 	save_data["state"] = self.state
 
 	if is_instance_valid(self.node):
+		if self.node is ESCItem:
+			if self.node.animations != null:
+				var a = (self.node as ESCItem).animations
+				save_data["animations_resource_path"] = (self.node as ESCItem).animations.resource_path
+				save_data["current_animation"] = (self.node as ESCItem).get_animation_player().get_current_animation()
+
 		if self.node.get("is_movable") and self.node.is_movable:
 			save_data["global_transform"] = self.node.global_transform
 			save_data["last_deg"] = wrapi(self.node._movable._get_angle() - 90 + 1, 0, 360)
@@ -200,7 +206,9 @@ func get_save_data() -> Dictionary:
 
 	if self.global_id in ["_music", "_sound", "_ambient"] and self.node.get("state"):
 		save_data["state"] = self.node.get("state")
-		if escoria.settings_manager.get_settings_dict()[ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION]:
+		if ESCProjectSettingsManager.get_setting(
+				ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION
+			):
 			save_data["playback_position"] = self.node.get_playback_position()
 
 	if self.global_id == "_camera":

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -183,7 +183,7 @@ func _set_interactive(value: bool):
 func get_save_data() -> Dictionary:
 	var save_data: Dictionary = {}
 
-	if self.global_id == "player" and not is_instance_valid(self.node):
+	if self.node is ESCPlayer and not is_instance_valid(self.node):
 		return save_data
 
 	save_data["active"] = self.active
@@ -206,14 +206,14 @@ func get_save_data() -> Dictionary:
 		if self.node.has_method("get_custom_data"):
 			save_data["custom_data"] = self.node.get_custom_data()
 
-	if self.global_id in ["_music", "_sound", "_ambient"] and self.node.get("state"):
+	if self.global_id in [ESCObjectManager.MUSIC, ESCObjectManager.SOUND, ESCObjectManager.AMBIENT] and self.node.get("state"):
 		save_data["state"] = self.node.get("state")
 		if ESCProjectSettingsManager.get_setting(
 				ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION
 			):
 			save_data["playback_position"] = self.node.get_playback_position()
 
-	if self.global_id == "_camera":
+	if self.global_id == ESCObjectManager.CAMERA:
 		save_data["target"] = self.node.get("_follow_target").global_id
 		var camera_limit_id = escoria.main.get_camera_limit_id_for_room(escoria.main.current_scene)
 		if camera_limit_id != null:

--- a/addons/escoria-core/game/core-scripts/esc_animation_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_animation_player.gd
@@ -201,6 +201,7 @@ func has_animation(name: String) -> bool:
 ## [br]
 ## Returns nothing.
 func seek_end(name: String):
+	_current_animation = name
 	if _is_animation_player:
 		_animation_player.current_animation = name
 		_animation_player.seek(_animation_player.get_animation(name).length, true)

--- a/addons/escoria-core/game/core-scripts/esc_animation_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_animation_player.gd
@@ -28,7 +28,8 @@ var _animated_sprite: AnimatedSprite2D
 var _is_animation_player: bool = false
 
 ## Currently running animation.
-var _current_animation: String = ""
+var _current_animation: String = "":
+	get = get_current_animation
 
 
 ## Create a new animation player.[br]
@@ -271,3 +272,16 @@ func _on_animation_finished(name: String):
 ## Returns nothing.
 func _on_animation_finished_animated_sprite():
 	_on_animation_finished(_current_animation)
+
+
+## Gets the current animation name.[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## A string containing the current animation name.
+func get_current_animation() -> String:
+	return _current_animation

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -305,6 +305,7 @@ func _ready():
 		if not escoria.event_manager.event_finished.is_connected(_update_terrain):
 			escoria.event_manager.event_finished.connect(_update_terrain)
 
+		_force_registration = true if escoria.save_manager.is_loading_game else false
 		escoria.object_manager.register_object(
 			ESCObject.new(
 				global_id,
@@ -670,8 +671,8 @@ func set_animations(p_animations: ESCAnimationResource) -> void:
 
 	animations = p_animations
 
-	if not animations.changed.is_connected(validate_animations):
-		animations.changed.connect(validate_animations)
+	if not animations.is_connected("changed", Callable(self, "_validate_animations")):
+		animations.connect("changed", Callable(self, "_validate_animations"))
 
 
 ## The animation player node[br]

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -671,8 +671,8 @@ func set_animations(p_animations: ESCAnimationResource) -> void:
 
 	animations = p_animations
 
-	if not animations.is_connected("changed", Callable(self, "_validate_animations")):
-		animations.connect("changed", Callable(self, "_validate_animations"))
+	if not animations.changed.is_connected(validate_animations):
+		animations.changed.connect(validate_animations)
 
 
 ## The animation player node[br]

--- a/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd
+++ b/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd
@@ -672,8 +672,8 @@ func set_animations(p_animations: ESCAnimationResource) -> void:
 
 	animations = p_animations
 
-	if not animations.is_connected("changed", Callable(self, "_validate_animations")):
-		animations.connect("changed", Callable(self, "_validate_animations"))
+	if not animations.changed.is_connected(validate_animations):
+		animations.changed.connect(validate_animations)
 
 
 ## The animation player node[br]

--- a/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd
+++ b/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.6.gd
@@ -306,6 +306,7 @@ func _ready():
 		if not escoria.event_manager.event_finished.is_connected(_update_terrain):
 			escoria.event_manager.event_finished.connect(_update_terrain)
 
+		_force_registration = true if escoria.save_manager.is_loading_game else false
 		escoria.object_manager.register_object(
 			ESCObject.new(
 				global_id,

--- a/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd
+++ b/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd
@@ -670,8 +670,8 @@ func set_animations(p_animations: ESCAnimationResource) -> void:
 
 	animations = p_animations
 
-	if not animations.is_connected("changed", Callable(self, "_validate_animations")):
-		animations.connect("changed", Callable(self, "_validate_animations"))
+	if not animations.changed.is_connected(validate_animations):
+		animations.changed.connect(validate_animations)
 
 
 ## The animation player node[br]

--- a/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd
+++ b/addons/escoria-core/game/core-scripts/pre-4.7/esc_item.4.7.gd
@@ -305,6 +305,7 @@ func _ready():
 		if not escoria.event_manager.event_finished.is_connected(_update_terrain):
 			escoria.event_manager.event_finished.connect(_update_terrain)
 
+		_force_registration = true if escoria.save_manager.is_loading_game else false
 		escoria.object_manager.register_object(
 			ESCObject.new(
 				global_id,

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -59,6 +59,7 @@ var _set_item_custom_data: SetItemCustomDataCommand
 var _teleport_pos: TeleportPosCommand
 var _set_direction: SetDirectionCommand
 var _set_global: SetGlobalCommand
+var _set_speed: SetSpeedCommand
 var _set_state: SetStateCommand
 var _stop_snd: StopSndCommand
 var _play_snd: PlaySndCommand
@@ -94,6 +95,7 @@ func _init():
 	_set_animations = SetAnimationsCommand.new()
 	_set_direction = SetDirectionCommand.new()
 	_set_global = SetGlobalCommand.new()
+	_set_speed = SetSpeedCommand.new()
 	_set_state = SetStateCommand.new()
 	_stop_snd = StopSndCommand.new()
 	_play_snd = PlaySndCommand.new()
@@ -539,6 +541,10 @@ func _load_object(object_id: String, object_dictionary: Dictionary, _room_id: St
 				object_dictionary["global_transform"].origin.x,
 				object_dictionary["global_transform"].origin.y
 			])
+
+		# Speed 
+		if object_dictionary.has("speed"):
+			_set_speed.run([object_id, object_dictionary["speed"]])
 
 		# Orientation
 		if object_dictionary.has("last_dir"):

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -547,7 +547,7 @@ func _load_object(object_id: String, object_dictionary: Dictionary, _room_id: St
 				object_dictionary["global_transform"].origin.y
 			])
 
-		# Speed 
+		# Speed
 		if object_dictionary.has("speed"):
 			_set_speed.run([object_id, object_dictionary["speed"]])
 

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -527,7 +527,12 @@ func _load_object(object_id: String, object_dictionary: Dictionary, _room_id: St
 		# Animations
 		if object_dictionary.has("animations_resource_path") and _set_animations.validate([object_id, object_dictionary["animations_resource_path"]]):
 			_set_animations.run([object_id, object_dictionary["animations_resource_path"]])
-		if object_dictionary.has("current_animation"):
+		if object_dictionary.has("current_animation")\
+				and _set_state.validate([
+					object_id,
+					object_dictionary["current_animation"],
+					true
+				]):
 			_set_state.run([object_id, object_dictionary["current_animation"], true])
 
 		# State

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -53,6 +53,7 @@ var _change_scene: ChangeSceneCommand
 var _enable_terrain: EnableTerrainCommand
 var _set_active: SetActiveCommand
 var _set_active_if_exists: SetActiveIfExistsCommand
+var _set_animations: SetAnimationsCommand
 var _set_interactive: SetInteractiveCommand
 var _set_item_custom_data: SetItemCustomDataCommand
 var _teleport_pos: TeleportPosCommand
@@ -90,6 +91,7 @@ func _init():
 	_set_interactive = SetInteractiveCommand.new()
 	_set_item_custom_data = SetItemCustomDataCommand.new()
 	_teleport_pos = TeleportPosCommand.new()
+	_set_animations = SetAnimationsCommand.new()
 	_set_direction = SetDirectionCommand.new()
 	_set_global = SetGlobalCommand.new()
 	_set_state = SetStateCommand.new()
@@ -519,6 +521,12 @@ func _load_object(object_id: String, object_dictionary: Dictionary, _room_id: St
 		# Interactive
 		if object_dictionary.has("interactive") and _set_interactive.validate([object_id, object_dictionary["interactive"]]):
 			_set_interactive.run([object_id, object_dictionary["interactive"]])
+
+		# Animations
+		if object_dictionary.has("animations_resource_path") and _set_animations.validate([object_id, object_dictionary["animations_resource_path"]]):
+			_set_animations.run([object_id, object_dictionary["animations_resource_path"]])
+		if object_dictionary.has("current_animation"):
+			_set_state.run([object_id, object_dictionary["current_animation"], true])
 
 		# State
 		if object_dictionary.has("state") and _set_state.validate([object_id, object_dictionary["state"], true]):

--- a/project.godot
+++ b/project.godot
@@ -16,7 +16,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="Escoria"
 run/main_scene="res://addons/escoria-core/game/main_scene.tscn"
-config/features=PackedStringArray("4.6")
+config/features=PackedStringArray("4.7")
 boot_splash/bg_color=Color(0.960784, 0.384314, 0, 1)
 boot_splash/stretch_mode=0
 boot_splash/use_filter=false
@@ -100,6 +100,7 @@ debug/enable_hover_stack_viewer=true
 main/escoria_version="4.0-alpha"
 debug/perform_script_analysis_at_runtime=true
 wizard/path_to_rooms="res://game/rooms"
+main/save_sounds_playback_position=true
 
 [file_customization]
 


### PR DESCRIPTION
Saves the ESCItem's current resource file into the savegame so it is loaded when loading the savegame. The current animation is also saved so it is set upon loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved games now restore item animations, current animation states, and movable-object speeds.
  * Sound playback positions are preserved when loading saved games.
  * Animation resources are validated and restored more reliably during game loading.

* **Bug Fixes**
  * Improved animation tracking when animations reach their end.
  * Corrected animation resource assignment during save restoration.
  * Improved save and restore reliability for game objects.
  * Updated compatibility with Godot 4.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->