### PR TITLE
fix: Set and unset input map actions properly in plugins enable/disable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ bin
 .godot
 .vscode
 
+# Ignore 4.6/4.7 core backups files
+addons/escoria-core/game/core-scripts/pre-4.7/*.bak
+addons/escoria-core/game/core-scripts/pre-4.7/last_version_used.json
+
 # Local overrides to project.godot go in override.cfg.
 /override.cfg
 

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -208,7 +208,9 @@ func get_save_data() -> Dictionary:
 
 	if self.global_id in [ESCObjectManager.MUSIC, ESCObjectManager.SOUND, ESCObjectManager.AMBIENT] and self.node.get("state"):
 		save_data["state"] = self.node.get("state")
-		if ESCProjectSettingsManager.get_setting(
+		if ESCProjectSettingsManager.has_setting(
+				ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION
+				) and ESCProjectSettingsManager.get_setting(
 				ESCProjectSettingsManager.SAVE_SOUNDS_PLAYBACK_POSITION
 			):
 			save_data["playback_position"] = self.node.get_playback_position()

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -548,7 +548,8 @@ func _load_object(object_id: String, object_dictionary: Dictionary, _room_id: St
 			])
 
 		# Speed
-		if object_dictionary.has("speed"):
+		if object_dictionary.has("speed") \
+				and _set_speed.validate([object_id, object_dictionary["speed"]]):
 			_set_speed.run([object_id, object_dictionary["speed"]])
 
 		# Orientation

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -12,6 +12,9 @@ const ESC_SCRIPT_EXTENSION = "esc"
 const ASH_SCRIPT_EXTENSION = "ash"
 const ASHES_ANALYZER_MENU_ITEM = "Analyze ASHES Scripts"
 
+# Input map actions
+const ESC_SHOW_DEBUG_PROMPT_ACTION_PATH = "input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT
+
 
 ## The warning popup displayed on escoria-core enabling.
 var popup_info: AcceptDialog
@@ -221,12 +224,12 @@ func _set_escoria_ui_settings():
 ## Returns nothing.
 func _set_inputmap():
 	# Show debug prompt
-	if not ProjectSettings.get("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT):
+	if not ProjectSettings.get(ESC_SHOW_DEBUG_PROMPT_ACTION_PATH):
 		InputMap.add_action(ESCInputsManager.ESC_SHOW_DEBUG_PROMPT)
 		var f2_ev = InputEventKey.new()
 		f2_ev.physical_keycode = KEY_F2
 		InputMap.action_add_event(ESCInputsManager.ESC_SHOW_DEBUG_PROMPT, f2_ev)
-		ProjectSettings.set_setting("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT, 
+		ProjectSettings.set_setting(ESC_SHOW_DEBUG_PROMPT_ACTION_PATH,
 			{
 				"deadzone": 0.2,
 				"events": [f2_ev]
@@ -245,9 +248,9 @@ func _set_inputmap():
 ## Returns nothing.
 func _unset_inputmap():
 	# Show debug prompt
-	if ProjectSettings.get("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT):
+	if ProjectSettings.get(ESC_SHOW_DEBUG_PROMPT_ACTION_PATH):
 		InputMap.erase_action(ESCInputsManager.ESC_SHOW_DEBUG_PROMPT)
-		ProjectSettings.set_setting("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT, null)
+		ProjectSettings.set_setting(ESC_SHOW_DEBUG_PROMPT_ACTION_PATH, null)
 		ProjectSettings.save()
 
 

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -44,6 +44,7 @@ func _enable_plugin():
 	_set_escoria_sound_settings()
 	_set_escoria_platform_settings()
 	_set_filesystem_show_esc_files()
+	_set_inputmap()
 
 	# Define standard settings
 	ProjectSettings.set_setting(
@@ -91,6 +92,7 @@ func _on_warning_popup_confirmed():
 func _disable_plugin():
 	remove_autoload_singleton("escoria")
 	_set_filesystem_hide_esc_files()
+	_unset_inputmap()
 
 
 ## Called when Escoria plugin gets added to Godot Editor's tree.[br]
@@ -206,6 +208,47 @@ func _set_escoria_ui_settings():
 			"type": TYPE_PACKED_STRING_ARRAY
 		}
 	)
+
+
+## Sets up Escoria core actions in the Input Map[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func _set_inputmap():
+	# Show debug prompt
+	if not ProjectSettings.get("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT):
+		InputMap.add_action(ESCInputsManager.ESC_SHOW_DEBUG_PROMPT)
+		var f2_ev = InputEventKey.new()
+		f2_ev.physical_keycode = KEY_F2
+		InputMap.action_add_event(ESCInputsManager.ESC_SHOW_DEBUG_PROMPT, f2_ev)
+		ProjectSettings.set_setting("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT, 
+			{
+				"deadzone": 0.2,
+				"events": [f2_ev]
+			})
+		ProjectSettings.save()
+
+
+## Removes Escoria core actions from the Input Map[br]
+## [br]
+## #### Parameters[br]
+## [br]
+## None.
+## [br]
+## #### Returns[br]
+## [br]
+## Returns nothing.
+func _unset_inputmap():
+	# Show debug prompt
+	if ProjectSettings.get("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT):
+		InputMap.erase_action(ESCInputsManager.ESC_SHOW_DEBUG_PROMPT)
+		ProjectSettings.set_setting("input/" + ESCInputsManager.ESC_SHOW_DEBUG_PROMPT, null)
+		ProjectSettings.save()
 
 
 ## Prepare the settings in the Escoria main category[br]

--- a/addons/escoria-ui-simplemouse/constants.gd
+++ b/addons/escoria-ui-simplemouse/constants.gd
@@ -1,0 +1,3 @@
+class_name SimpleMouseConstants
+
+const ESC_UI_CHANGE_VERB_ACTION = "esc_change_verb"

--- a/addons/escoria-ui-simplemouse/constants.gd.uid
+++ b/addons/escoria-ui-simplemouse/constants.gd.uid
@@ -1,0 +1,1 @@
+uid://bljmw8j0qjmeg

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -59,9 +59,6 @@ const PRIMARY_ACTION_BUTTON = JOY_BUTTON_X
 # map to the "secondary action," in practice, so we treat it like a right click.
 const CHANGE_VERB_BUTTON = JOY_BUTTON_Y
 
-# Input action for use by InputMap
-const ESC_UI_CHANGE_VERB_ACTION = "esc_change_verb"
-
 var targeted_node: Node
 
 # true when a gamepad is connected.
@@ -130,16 +127,14 @@ func _on_gamepad_connected():
 
 	var verb_event = InputEventJoypadButton.new()
 	verb_event.button_index = CHANGE_VERB_BUTTON
-	InputMap.add_action(ESC_UI_CHANGE_VERB_ACTION)
-	InputMap.action_add_event(ESC_UI_CHANGE_VERB_ACTION, verb_event)
+	InputMap.action_add_event(SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION, verb_event)
 
 
 func _on_gamepad_disconnected():
 	InputMap.action_erase_events(escoria.inputs_manager.ESC_UI_PRIMARY_ACTION)
 	InputMap.erase_action(escoria.inputs_manager.ESC_UI_PRIMARY_ACTION)
 
-	InputMap.action_erase_events(ESC_UI_CHANGE_VERB_ACTION)
-	InputMap.erase_action(ESC_UI_CHANGE_VERB_ACTION)
+	InputMap.action_erase_events(SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION)
 
 	set_physics_process(false)
 	_is_gamepad_connected = false
@@ -188,7 +183,7 @@ func _process_input(event: InputEvent, is_default_state: bool) -> bool:
 			escoria.inputs_manager._on_left_click_on_bg(get_global_mouse_position())
 			return true
 
-	if event.is_action_pressed(ESC_UI_CHANGE_VERB_ACTION):
+	if event.is_action_pressed(SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION):
 		mousewheel_action(1)
 		return true
 	return false

--- a/addons/escoria-ui-simplemouse/plugin.gd
+++ b/addons/escoria-ui-simplemouse/plugin.gd
@@ -2,6 +2,8 @@
 # Plugin script to initialize Escoria simple mouse UI
 extends EditorPlugin
 
+const ESC_CHANGE_VERB_CREATED_SETTING = "escoria/internal/esc_change_verb_created_by_simplemouse_plugin"
+
 
 # Override function to return the plugin name.
 func _get_plugin_name():
@@ -12,10 +14,20 @@ func _get_plugin_name():
 func _disable_plugin():
 	print("Disabling plugin Escoria UI Simple Mouse.")
 	EscoriaPlugin.deregister_ui("res://addons/escoria-ui-simplemouse/game.tscn")
-	
-	if ProjectSettings.get("input/"+SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION):
+
+	var action_path := "input/" + SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION
+	var action_setting = ProjectSettings.get(action_path)
+	var created_by_plugin: bool = ProjectSettings.get_setting(
+		ESC_CHANGE_VERB_CREATED_SETTING,
+		false
+	)
+
+	if created_by_plugin and action_setting:
 		InputMap.erase_action(SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION)
-		ProjectSettings.set_setting("input/" + SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION, null)
+		ProjectSettings.set_setting(action_path, null)
+
+	if created_by_plugin:
+		ProjectSettings.set_setting(ESC_CHANGE_VERB_CREATED_SETTING, false)
 		ProjectSettings.save()
 
 
@@ -28,11 +40,20 @@ func _enable_plugin():
 			false
 		)
 
-	if not ProjectSettings.get("input/"+SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION):
+	var action_path := "input/" + SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION
+	var action_setting = ProjectSettings.get(action_path)
+
+	if not action_setting:
 		InputMap.add_action(SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION)
-		ProjectSettings.set_setting("input/" + SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION, 
+		ProjectSettings.set_setting(action_path,
 		{
 			"deadzone": 0.2,
 			"events": []
 		})
+		ProjectSettings.set_setting(ESC_CHANGE_VERB_CREATED_SETTING, true)
+		ProjectSettings.save()
+	else:
+		# Existing project mapping: mark as not plugin-created so disable won't erase it.
+		if ProjectSettings.get_setting(ESC_CHANGE_VERB_CREATED_SETTING, false):
+			ProjectSettings.set_setting(ESC_CHANGE_VERB_CREATED_SETTING, false)
 		ProjectSettings.save()

--- a/addons/escoria-ui-simplemouse/plugin.gd
+++ b/addons/escoria-ui-simplemouse/plugin.gd
@@ -12,6 +12,11 @@ func _get_plugin_name():
 func _disable_plugin():
 	print("Disabling plugin Escoria UI Simple Mouse.")
 	EscoriaPlugin.deregister_ui("res://addons/escoria-ui-simplemouse/game.tscn")
+	
+	if ProjectSettings.get("input/"+SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION):
+		InputMap.erase_action(SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION)
+		ProjectSettings.set_setting("input/" + SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION, null)
+		ProjectSettings.save()
 
 
 # Register UI with Escoria
@@ -22,3 +27,12 @@ func _enable_plugin():
 			_get_plugin_name(),
 			false
 		)
+
+	if not ProjectSettings.get("input/"+SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION):
+		InputMap.add_action(SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION)
+		ProjectSettings.set_setting("input/" + SimpleMouseConstants.ESC_UI_CHANGE_VERB_ACTION, 
+		{
+			"deadzone": 0.2,
+			"events": []
+		})
+		ProjectSettings.save()

--- a/project.godot
+++ b/project.godot
@@ -29,7 +29,7 @@ buses/default_bus_layout="res://addons/escoria-core/buses/default_bus_layout.tre
 
 [autoload]
 
-escoria="*res://addons/escoria-core/game/esc_autoload.gd"
+escoria="*uid://dcskv8vx80gov"
 
 [display]
 
@@ -88,6 +88,11 @@ ui/default_dialog_scene="res://addons/escoria-core/ui_library/dialogs/floating_d
 main/action_default_script="res://action_defaults.esc"
 dialog_simple/text_speed_per_character=0.1
 dialog_simple/fast_text_speed_per_character=0.25
+debug/enable_hover_stack_viewer=true
+main/escoria_version="4.0-alpha"
+debug/perform_script_analysis_at_runtime=true
+wizard/path_to_rooms="res://game/rooms"
+main/save_sounds_playback_position=true
 ui/default_dialog_type="floating"
 dialog_simple/avatars_path="res://game/dialog_avatars"
 dialog_simple/text_time_per_letter_ms=100
@@ -115,9 +120,13 @@ settings/test/test_lookup_folder="testing"
 [input]
 
 esc_show_debug_prompt={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194333,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":16,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194333,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
+}
+esc_change_verb={
+"deadzone": 0.2,
+"events": []
 }
 
 [internationalization]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an F2 shortcut for opening the Escoria debug prompt.
  * Added support for changing verbs through a configured input action, including gamepad controls.
  * Added settings for hover-stack viewing, version identification, runtime script analysis, room discovery, and saving sound playback positions.

* **Bug Fixes**
  * Improved creation and cleanup of plugin input actions when plugins are enabled or disabled.

* **Chores**
  * Excluded temporary backup files and generated version data from source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->